### PR TITLE
Updated outputs values

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,48 +1,48 @@
 output "DC_ID" {
   description = "id of vSphere Datacenter"
-  value       = "${data.vsphere_datacenter.dc.id}"
+  value       = data.vsphere_datacenter.dc.id
 }
 output "ResPool_ID" {
   description = "Resource Pool id"
-  value       = "${data.vsphere_resource_pool.pool.id}"
+  value       = data.vsphere_resource_pool.pool.id
 }
 
 output "Windows-VM" {
   description = "VM Names"
-  value       = ["${vsphere_virtual_machine.Windows.*.name}"]
+  value       = vsphere_virtual_machine.Windows.*.name
 }
 
 output "Windows-ip" {
   description = "default ip address of the deployed VM"
-  value       = ["${vsphere_virtual_machine.Windows.*.default_ip_address}"]
+  value       = vsphere_virtual_machine.Windows.*.default_ip_address
 }
 
 output "Windows-guest-ip" {
   description = "all the registered ip address of the VM"
-  value       = ["${vsphere_virtual_machine.Windows.*.guest_ip_addresses}"]
+  value       = vsphere_virtual_machine.Windows.*.guest_ip_addresses
 }
 
 output "Windows-uuid" {
   description = "UUID of the VM in vSphere"
-  value       = ["${vsphere_virtual_machine.Windows.*.uuid}"]
+  value       = vsphere_virtual_machine.Windows.*.uuid
 }
 
 output "Linux-VM" {
   description = "VM Names"
-  value       = ["${vsphere_virtual_machine.Linux.*.name}"]
+  value       = vsphere_virtual_machine.Linux.*.name
 }
 
 output "Linux-ip" {
   description = "default ip address of the deployed VM"
-  value       = ["${vsphere_virtual_machine.Linux.*.default_ip_address}"]
+  value       = vsphere_virtual_machine.Linux.*.default_ip_address
 }
 
 output "Linux-guest-ip" {
   description = "all the registered ip address of the VM"
-  value       = ["${vsphere_virtual_machine.Linux.*.guest_ip_addresses}"]
+  value       = vsphere_virtual_machine.Linux.*.guest_ip_addresses
 }
 
 output "Linux-uuid" {
   description = "UUID of the VM in vSphere"
-  value       = ["${vsphere_virtual_machine.Linux.*.uuid}"]
+  value       = vsphere_virtual_machine.Linux.*.uuid
 }


### PR DESCRIPTION
When I try to access the outputs for the modules, specifically Linux-VM and Linux-IP, and create a map of hostnames to IPs terraform fails with an error that module.module_name.Linux-VM is a string not a list (simplified error). This PR fixes the values in output.tf so that outputs external of the module can can reference them to create new outputs.