### PR TITLE
Documentation fix, wait_for vars, var typing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # Terraform vSphere Module (:star2: All new features)
 
-For Virtual Machine Provisioning with (Linux/Windows) customization. Thanks to the new enhancements introduced in Terraform v0.12.6 this module include most of the advance features that are available in the resource `vsphere_virtual_machine`. 
+For Virtual Machine Provisioning with (Linux/Windows) customization. Thanks to the new enhancements introduced in Terraform v0.12.6 this module include most of the advance features that are available in the resource `vsphere_virtual_machine`.
 
-:warning: The new version of this module only works with terraform version 0.12.6 and above :warning: 
+:warning: The new version of this module only works with terraform version 0.12.6 and above :warning:
 
 > This module now replace the functionality of the following modules:
-> * [`Terraform-VMWare-Modules-vm2nic`](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm2nic/vsphere/0.1.0)
-> * [`Terraform-VMWare-Modules-vm3nic`](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm3nic/vsphere/0.1.0)
+>
+> - [`Terraform-VMWare-Modules-vm2nic`](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm2nic/vsphere/0.1.0)
+> - [`Terraform-VMWare-Modules-vm3nic`](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm3nic/vsphere/0.1.0)
 
 ## Deploys (Single/Multiple) Virtual Machines to your vSphere environment
 
 This Terraform module deploys single or multiple virtual machines of type (Linux/Windows) with following features:
 
-* Ability to specify Linux or Windows VM customization.
-* Ability to add extra data disk (up to 15) to the VM.
-* Ability to deploy Multiple instances.
-* Ability to set IP and Gateway configuration for the VM.
-* Ability to add multiple network cards for the VM
-* Ability to choose vSphere resource pool or fall back to Cluster/ESXi root resource pool.
-* Ability to deploy Windows images to WorkGroup or Domain.
-* Ability to output VM names and IPs per module.
-* Ability assign tags and custom variables.
-* Ability to configure advance features for the vm.
-* Ability to deploy either a datastore or a datastore cluster.
-* Ability to enable cpu and memory hot plug features for the VM.
+- Ability to specify Linux or Windows VM customization.
+- Ability to add extra data disk (up to 15) to the VM.
+- Ability to deploy Multiple instances.
+- Ability to set IP and Gateway configuration for the VM.
+- Ability to add multiple network cards for the VM
+- Ability to choose vSphere resource pool or fall back to Cluster/ESXi root resource pool.
+- Ability to deploy Windows images to WorkGroup or Domain.
+- Ability to output VM names and IPs per module.
+- Ability assign tags and custom variables.
+- Ability to configure advance features for the vm.
+- Ability to deploy either a datastore or a datastore cluster.
+- Ability to enable cpu and memory hot plug features for the VM.
 
 > Note: For module to work it needs number of required variables corresponding to an existing resources in vSphere. Please refer to variable section for the list of required variables.
 
@@ -36,14 +37,14 @@ You can also download the entire module and use your own predefined variables to
 ```hcl
 module "example-server-linuxvm" {
   source        = "Terraform-VMWare-Modules/vm/vsphere"
-  version       = "1.0.0"
+  version       = "1.0.2"
   vmtemp        = "TemplateName"
   instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the POrt Group in vSphere"]
+  network_cards = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -51,15 +52,15 @@ module "example-server-linuxvm" {
 
 module "example-server-windowsvm" {
   source           = "Terraform-VMWare-Modules/vm/vsphere"
-  version          = "1.0.0"
+  version          = "1.0.2"
   vmtemp           = "TemplateName"
   is_windows_image = "true"
   instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
-  network_cards    = ["Name of the POrt Group in vSphere"]
+  network_cards    = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -74,22 +75,22 @@ There are number of switches defined in the module, where you can use to enable 
 
 ### Main Feature Switches
 
-* You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
-* You can use `data_disk_size_gb = [20,30]` to add one additional disk (Supported in both Linux and Windows deployment)
-  * Above switch will create two additional disk of capacity 10 and 30gb for the VM.
-  * You can include `thin_provisioned` switch to define disk type for each additional disk.
-* You can use `windomain = "somedomain.com"` to join a windows server to AD domain.
-  * Requires following additional variables
-    * `domainuser` Domain account with necessary privileges to join a computer to the domain.
-    * `domainpass` Domain user password.
-    * `is_windows_image` needs to be set to `true` to force the module to use Windows customization.
+- You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
+- You can use `data_disk_size_gb = [20,30]` to add additional data disks (SupPorted in both Linux and Windows deployment)
+  - Above switch will create two additional disk of capacity 10 and 30gb for the VM.
+  - You can include `thin_provisioned` switch to define disk type for each additional disk.
+- You can use `windomain = "somedomain.com"` to join a windows server to AD domain.
+  - Requires following additional variables
+    - `domainuser` Domain account with necessary privileges to join a computer to the domain.
+    - `domainpass` Domain user password.
+    - `is_windows_image` needs to be set to `true` to force the module to use Windows customization.
 
 Below is an example of windows deployment with some of the available feature sets.
 
 ```hcl
 module "example-server-windowsvm-advanced" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.0"
+  version                = "1.0.2"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources" #Works with ESXi/Resources
   vmfolder               = "Cattle"
@@ -103,7 +104,7 @@ module "example-server-windowsvm-advanced" {
   memory_hot_add_enabled = "true"
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-netwrok"] #Assign multiple cards
+  network_cards          = ["VM Network", "test-network"] #Assign multiple cards
   ipv4submask            = ["24", "8"]
   ipv4 = { #assign IPs per card
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
@@ -119,7 +120,7 @@ module "example-server-windowsvm-advanced" {
   }
   enable_disk_uuid = "true"
   auto_logon       = "true"
-  run_once         = ["command01", "command02"]
+  run_once         = ["command01", "command02"] // You can also run Powershell commands
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
   is_windows_image = "true"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are number of switches defined in the module, where you can use to enable 
 ### Main Feature Switches
 
 - You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
-- You can use `data_disk_size_gb = [20,30]` to add additional data disks (SupPorted in both Linux and Windows deployment)
+- You can use `data_disk_size_gb = [20,30]` to add additional data disks (Supported in both Linux and Windows deployment)
   - Above switch will create two additional disk of capacity 10 and 30gb for the VM.
   - You can include `thin_provisioned` switch to define disk type for each additional disk.
 - You can use `windomain = "somedomain.com"` to join a windows server to AD domain.

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -50,7 +50,7 @@ module "example-server-linuxvm-withdatadisk" {
   memory_hot_add_enabled = "true"
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-netwrok"]
+  network_cards          = ["VM Network", "test-network"]
   ipv4submask            = ["24", "8"]
   ipv4 = {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -13,21 +13,21 @@ Following example contains the bare minimum options to be configured for the Lin
 ```hcl
 module "example-server-linuxvm" {
   source            = "Terraform-VMWare-Modules/vm/vsphere"
-  version           = "1.0.0"
+  version           = "1.0.2"
   vmtemp            = "TemplateName"
   instances         = 1
   vmname            = "example-server-windows"
-  vmrp              = "esxi/Resources"  
-  network_cards     = ["Name of the POrt Group in vSphere"]
+  vmrp              = "esxi/Resources"
+  network_cards     = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
   }
   dc                = "Datacenter"
-  datastore         = "Data Store name(use ds_cluster for datastore cluster)" 
+  datastore         = "Data Store name(use ds_cluster for datastore cluster)"
 }
 ```
 
-### Example of Advanced Linux VM Customization 
+### Example of Advanced Linux VM Customization
 
 Below example will deploy 2 instance of a virtual machine from a linux template. The virtual machines are configured to use 2 network cards with 2 additional disk.
 
@@ -36,7 +36,7 @@ Below example will deploy 2 instance of a virtual machine from a linux template.
 ```hcl
 module "example-server-linuxvm-withdatadisk" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.0"
+  version                = "1.0.2"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -30,7 +30,7 @@ module "example-server-linuxvm-advanced" {
   memory_hot_add_enabled = "true"
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-netwrok"]
+  network_cards          = ["VM Network", "test-network"]
   ipv4submask            = ["24", "8"]
   ipv4 = {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -1,14 +1,14 @@
 // Simple Linux VM deployment
 module "example-server-linuxvm" {
   source        = "Terraform-VMWare-Modules/vm/vsphere"
-  version       = "1.0.0"
+  version       = "1.0.2"
   vmtemp        = "TemplateName"
   instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the POrt Group in vSphere"]
+  network_cards = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -16,7 +16,7 @@ module "example-server-linuxvm" {
 // Example of Linux VM with more Advanced Features
 module "example-server-linuxvm-advanced" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.0"
+  version                = "1.0.2"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
@@ -36,7 +36,7 @@ module "example-server-linuxvm-advanced" {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP
     "test"       = ["", "192.168.0.3"]
   }
-  data_disk_size_gb = [10, 5] // Aditional Disk to be used
+  data_disk_size_gb = [10, 5] // Aditional Disks to be used
   thin_provisioned  = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -13,14 +13,14 @@ Following example contains the bare minimum options to be configured for the Win
 ```hcl
 module "example-server-windowsvm-withdatadisk" {
   source        = "Terraform-VMWare-Modules/vm/vsphere"
-  version       = "1.0.0"
+  version       = "1.0.2"
   vmtemp        = "TemplateName"
   instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the POrt Group in vSphere"]
+  network_cards = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -32,7 +32,7 @@ module "example-server-windowsvm-withdatadisk" {
 ```hcl
 module "example-server-windowsvm-advanced" {
    source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.0"
+  version                = "1.0.2"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
@@ -52,7 +52,7 @@ module "example-server-windowsvm-advanced" {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
     "test"       = ["", "192.168.0.3"]
   }
-  data_disk_size_gb = [10, 5] // Aditional Disk to be used
+  data_disk_size_gb = [10, 5] // Aditional Disks to be used
   thin_provisioned  = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
@@ -62,11 +62,11 @@ module "example-server-windowsvm-advanced" {
   }
   enable_disk_uuid = "true"
   auto_logon       = "true"
-  run_once         = ["mkdir c:\\admin", "echo runonce-test >> c:\\admin\\logs.txt"]
+  run_once         = ["mkdir c:\\admin", "echo runonce-test >> c:\\admin\\logs.txt", "powershell.exe \"New-Item C:\\test.txt\""]
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
   is_windows_image = "true"
-  firmware         = "efi" 
+  firmware         = "efi"
   local_adminpass  = "Password@Strong"
 }
 ```

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -1,34 +1,34 @@
 // Example of basic Windows VM
 module "example-server-windowsvm-withdatadisk" {
   source           = "Terraform-VMWare-Modules/vm/vsphere"
-  version          = "1.0.0"
+  version          = "1.0.2"
   vmtemp           = "TemplateName"
   is_windows_image = "true"
   instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
-  network_cards    = ["Name of the POrt Group in vSphere"]
+  network_cards    = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
 }
 // Example of basic Windows VM joined to the domain
 module "example-server-windowsvm-withdatadisk" {
-  source           = "Terraform-VMWare-Modules/vm/vsphere"
-  version          = "1.0.0"
-  vmtemp           = "TemplateName"
-  is_windows_image = "true"
-  windomain        = "Development.com"
-  domain_admin_user = "Domain admin user"
+  source                = "Terraform-VMWare-Modules/vm/vsphere"
+  version               = "1.0.2"
+  vmtemp                = "TemplateName"
+  is_windows_image      = "true"
+  windomain             = "Development.com"
+  domain_admin_user     = "Domain admin user"
   domain_admin_password = "SomePassword"
-  instances        = 1
-  vmname           = "example-server-windows"
-  vmrp             = "esxi/Resources"
-  network_cards    = ["Name of the POrt Group in vSphere"]
+  instances             = 1
+  vmname                = "example-server-windows"
+  vmrp                  = "esxi/Resources"
+  network_cards         = ["Name of the Port Group in vSphere"]
   ipv4 = {
-    "Name of the POrt Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -36,7 +36,7 @@ module "example-server-windowsvm-withdatadisk" {
 //Example of Windows VM customization with advanced features
 module "example-server-windowsvm-advanced" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.0"
+  version                = "1.0.2"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
@@ -50,13 +50,13 @@ module "example-server-windowsvm-advanced" {
   memory_hot_add_enabled = "true"
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-netwrok"]
+  network_cards          = ["VM Network", "test-network"]
   ipv4submask            = ["24", "8"]
   ipv4 = {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
     "test"       = ["", "192.168.0.3"]
   }
-  data_disk_size_gb = [10, 5] // Aditional Disk to be used
+  data_disk_size_gb = [10, 5] // Aditional Disks to be used
   thin_provisioned  = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
@@ -66,7 +66,7 @@ module "example-server-windowsvm-advanced" {
   }
   enable_disk_uuid = "true"
   auto_logon       = "true"
-  run_once         = ["command01", "command02"]
+  run_once         = ["command01", "powershell.exe \"New-Item C:\\test.txt\""] // You can also run Powershell commands
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
   is_windows_image = "true"

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ data "vsphere_tag" "tag" {
 }
 
 locals {
-  interface_count = length(var.ipv4submask) #Used for Subnet handeling
+  interface_count     = length(var.ipv4submask) #Used for Subnet handeling
   template_disk_count = length(data.vsphere_virtual_machine.template.disks)
 }
 
@@ -73,6 +73,9 @@ resource "vsphere_virtual_machine" "Linux" {
   guest_id               = data.vsphere_virtual_machine.template.guest_id
   scsi_type              = data.vsphere_virtual_machine.template.scsi_type
 
+  wait_for_guest_net_routable = var.wait_for_guest_net_routable
+  wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
+  wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
 
   dynamic "network_interface" {
     for_each = var.network_cards
@@ -84,15 +87,15 @@ resource "vsphere_virtual_machine" "Linux" {
 
   // Disks defined in the original template
   dynamic "disk" {
-      for_each = data.vsphere_virtual_machine.template.disks
-      iterator = template_disks
-      content {
-          label            = "disk${template_disks.key}"
-          size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
-          unit_number      = template_disks.key
-          thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
-          eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
-      }
+    for_each = data.vsphere_virtual_machine.template.disks
+    iterator = template_disks
+    content {
+      label            = "disk${template_disks.key}"
+      size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      unit_number      = template_disks.key
+      thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
+      eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
+    }
   }
 
   // Additional disks defined by Terraform config
@@ -160,6 +163,9 @@ resource "vsphere_virtual_machine" "Windows" {
   guest_id               = data.vsphere_virtual_machine.template.guest_id
   scsi_type              = data.vsphere_virtual_machine.template.scsi_type
 
+  wait_for_guest_net_routable = var.wait_for_guest_net_routable
+  wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
+  wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
 
   dynamic "network_interface" {
     for_each = var.network_cards
@@ -171,15 +177,15 @@ resource "vsphere_virtual_machine" "Windows" {
 
   // Disks defined in the original template
   dynamic "disk" {
-      for_each = data.vsphere_virtual_machine.template.disks
-      iterator = template_disks
-      content {
-          label            = "disk${template_disks.key}"
-          size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
-          unit_number      = template_disks.key
-          thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
-          eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
-      }
+    for_each = data.vsphere_virtual_machine.template.disks
+    iterator = template_disks
+    content {
+      label            = "disk${template_disks.key}"
+      size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      unit_number      = template_disks.key
+      thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
+      eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
+    }
   }
 
   // Additional disks defined by Terraform config

--- a/variables.tf
+++ b/variables.tf
@@ -39,12 +39,12 @@ variable "network_cards" {
 
 variable "ipv4" {
   description = "host(VM) IP address in map format, support more than one IP. Should correspond to number of instances"
-  type        = "map"
+  type        = map
 }
 
 variable "ipv4submask" {
   description = "ipv4 Subnet mask"
-  type        = "list"
+  type        = list
   default     = ["24"]
 }
 
@@ -109,7 +109,7 @@ variable "annotation" {
 
 variable "linked_clone" {
   description = "Clone this virtual machine from a snapshot. Templates must have a single snapshot only in order to be eligible."
-  default     = "false"
+  default     = false
 }
 
 variable "timeout" {
@@ -152,19 +152,19 @@ variable "memory_hot_add_enabled" {
 
 variable "data_disk_size_gb" {
   description = "Storage data disk size size"
-  type        = "list"
+  type        = list
   default     = []
 }
 
 variable "thin_provisioned" {
   description = "If true, this disk is thin provisioned, with space for the file being allocated on an as-needed basis."
-  type        = "list"
+  type        = list
   default     = null
 }
 
 variable "eagerly_scrub" {
   description = "if set to true, the disk space is zeroed out on VM creation. This will delay the creation of the disk or virtual machine. Cannot be set to true when thin_provisioned is true."
-  type        = "list"
+  type        = list
   default     = null
 }
 
@@ -177,7 +177,7 @@ variable "enable_disk_uuid" {
 #Linux Customization Variables
 variable "hw_clock_utc" {
   description = "Tells the operating system that the hardware clock is set to UTC"
-  default     = "true"
+  default     = true
 }
 
 variable "vmdomain" {
@@ -189,7 +189,7 @@ variable "vmdomain" {
 #Windows Customization Variables
 variable "is_windows_image" {
   description = "Boolean flag to notify when the custom image is windows based."
-  default     = "false"
+  default     = false
 }
 
 variable "local_adminpass" {
@@ -201,7 +201,6 @@ variable "workgroup" {
   description = "The workgroup name for this virtual machine. One of this or join_domain must be included."
   default     = null
 }
-
 
 variable "windomain" {
   description = "The domain to join for this virtual machine. One of this or workgroup must be included."
@@ -252,4 +251,22 @@ variable "productkey" {
 variable "full_name" {
   description = "The full name of the user of this virtual machine. This populates the user field in the general Windows system information. Default - Administrator"
   default     = null
+}
+
+variable "wait_for_guest_net_routable" {
+  description = "Controls whether or not the guest network waiter waits for a routable address. When false, the waiter does not wait for a default gateway, nor are IP addresses checked against any discovered default gateways as part of its success criteria. This property is ignored if the wait_for_guest_ip_timeout waiter is used."
+  default     = true
+  type        = bool
+}
+
+variable "wait_for_guest_ip_timeout" {
+  description = "The amount of time, in minutes, to wait for an available guest IP address on this virtual machine. This should only be used if your version of VMware Tools does not allow the wait_for_guest_net_timeout waiter to be used. A value less than 1 disables the waiter."
+  default     = 0
+  type        = number
+}
+
+variable "wait_for_guest_net_timeout" {
+  description = "The amount of time, in minutes, to wait for an available IP address on this virtual machine's NICs. Older versions of VMware Tools do not populate this property. In those cases, this waiter can be disabled and the wait_for_guest_ip_timeout waiter can be used instead. A value less than 1 disables the waiter."
+  default     = 5
+  type        = number
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,3 @@
-
 terraform {
   required_version = ">= 0.12.6"
 }


### PR DESCRIPTION
- Fixed lot of typos
- Cleared some examples and descriptions
- Added these variables:
  - `wait_for_guest_net_routable`
  - `wait_for_guest_ip_timeout`
  - `wait_for_guest_net_timeout`
- Fixed variable typing to follow the latest Terraform 0.12 convention (no more deprecation warnings)