### PR TITLE
Feature/scsi controller selection

### DIFF
--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -16,7 +16,7 @@ module "example-server-linuxvm" {
 // Example of Linux VM with more Advanced Features
 module "example-server-linuxvm-advanced" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.2"
+  version                = "1.0.3"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
@@ -36,6 +36,9 @@ module "example-server-linuxvm-advanced" {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP
     "test"       = ["", "192.168.0.3"]
   }
+  scsi_type = "lsilogic" # "pvscsi"
+  scsi_controller = 0
+  data_disk_scsi_controller  = [0, 3]
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb = [10, 5] // Aditional Disks to be used

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -36,7 +36,7 @@ module "example-server-windowsvm-withdatadisk" {
 //Example of Windows VM customization with advanced features
 module "example-server-windowsvm-advanced" {
   source                 = "Terraform-VMWare-Modules/vm/vsphere"
-  version                = "1.0.2"
+  version                = "1.0.3"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
@@ -56,6 +56,9 @@ module "example-server-windowsvm-advanced" {
     "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
     "test"       = ["", "192.168.0.3"]
   }
+  scsi_type = "lsilogic" # "pvscsi"
+  scsi_controller = 0
+  data_disk_scsi_controller  = [0, 3]
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb = [10, 5] // Aditional Disks to be used

--- a/main.tf
+++ b/main.tf
@@ -198,7 +198,7 @@ resource "vsphere_virtual_machine" "Windows" {
     content {
       label            = "disk${template_disks.key}"
       size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
-      unit_number      = var.scsi_controller != null ? max(var.scsi_controller * 15 - 1, 0) + template_disks.key : template_disks.key
+      unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
       datastore_id     = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
@@ -212,7 +212,7 @@ resource "vsphere_virtual_machine" "Windows" {
     content {
       label            = "disk${terraform_disks.key + local.template_disk_count}"
       size             = var.data_disk_size_gb[terraform_disks.key]
-      unit_number      = length(var.data_disk_scsi_controller) > 0 ? max(var.data_disk_scsi_controller[terraform_disks.key] * 15 - 1, 0) + terraform_disks.key + local.template_disk_count : terraform_disks.key + local.template_disk_count
+      unit_number      = length(var.data_disk_scsi_controller) > 0 ? var.data_disk_scsi_controller[terraform_disks.key] * 15 + terraform_disks.key + (var.scsi_controller == var.data_disk_scsi_controller[terraform_disks.key] ? local.template_disk_count : 0) : terraform_disks.key + local.template_disk_count
       thin_provisioned = var.thin_provisioned != null ? var.thin_provisioned[terraform_disks.key] : null
       eagerly_scrub    = var.eagerly_scrub != null ? var.eagerly_scrub[terraform_disks.key] : null
       datastore_id     = length(var.data_disk_datastore) > 0 ? data.vsphere_datastore.data_disk_datastore[var.data_disk_datastore[terraform_disks.key]].id : null

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,8 @@ resource "vsphere_virtual_machine" "Linux" {
   memory                 = var.ram_size
   memory_hot_add_enabled = var.memory_hot_add_enabled
   guest_id               = data.vsphere_virtual_machine.template.guest_id
-  scsi_type              = data.vsphere_virtual_machine.template.scsi_type
+  scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
+  scsi_controller_count  = length(var.data_disk_scsi_controller) > 0 ? max(max(var.data_disk_scsi_controller...) + 1, var.scsi_controller) : 1
 
   wait_for_guest_net_routable = var.wait_for_guest_net_routable
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
@@ -104,7 +105,7 @@ resource "vsphere_virtual_machine" "Linux" {
     content {
       label            = "disk${template_disks.key}"
       size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
-      unit_number      = template_disks.key
+      unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
       datastore_id     = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
@@ -118,7 +119,7 @@ resource "vsphere_virtual_machine" "Linux" {
     content {
       label            = "disk${terraform_disks.key + local.template_disk_count}"
       size             = var.data_disk_size_gb[terraform_disks.key]
-      unit_number      = terraform_disks.key + local.template_disk_count
+      unit_number      = length(var.data_disk_scsi_controller) > 0 ? var.data_disk_scsi_controller[terraform_disks.key] * 15 + terraform_disks.key + (var.scsi_controller == var.data_disk_scsi_controller[terraform_disks.key] ? local.template_disk_count : 0) : terraform_disks.key + local.template_disk_count
       thin_provisioned = var.thin_provisioned != null ? var.thin_provisioned[terraform_disks.key] : null
       eagerly_scrub    = var.eagerly_scrub != null ? var.eagerly_scrub[terraform_disks.key] : null
       datastore_id     = length(var.data_disk_datastore) > 0 ? data.vsphere_datastore.data_disk_datastore[var.data_disk_datastore[terraform_disks.key]].id : null
@@ -176,6 +177,7 @@ resource "vsphere_virtual_machine" "Windows" {
   memory_hot_add_enabled = var.memory_hot_add_enabled
   guest_id               = data.vsphere_virtual_machine.template.guest_id
   scsi_type              = data.vsphere_virtual_machine.template.scsi_type
+  scsi_controller_count  = length(var.data_disk_scsi_controller) > 0 ? max(max(var.data_disk_scsi_controller...) + 1, var.scsi_controller) : 1
 
   wait_for_guest_net_routable = var.wait_for_guest_net_routable
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
@@ -196,7 +198,7 @@ resource "vsphere_virtual_machine" "Windows" {
     content {
       label            = "disk${template_disks.key}"
       size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
-      unit_number      = template_disks.key
+      unit_number      = var.scsi_controller != null ? max(var.scsi_controller * 15 - 1, 0) + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
       datastore_id     = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
@@ -210,7 +212,7 @@ resource "vsphere_virtual_machine" "Windows" {
     content {
       label            = "disk${terraform_disks.key + local.template_disk_count}"
       size             = var.data_disk_size_gb[terraform_disks.key]
-      unit_number      = terraform_disks.key + local.template_disk_count
+      unit_number      = length(var.data_disk_scsi_controller) > 0 ? max(var.data_disk_scsi_controller[terraform_disks.key] * 15 - 1, 0) + terraform_disks.key + local.template_disk_count : terraform_disks.key + local.template_disk_count
       thin_provisioned = var.thin_provisioned != null ? var.thin_provisioned[terraform_disks.key] : null
       eagerly_scrub    = var.eagerly_scrub != null ? var.eagerly_scrub[terraform_disks.key] : null
       datastore_id     = length(var.data_disk_datastore) > 0 ? data.vsphere_datastore.data_disk_datastore[var.data_disk_datastore[terraform_disks.key]].id : null

--- a/variables.tf
+++ b/variables.tf
@@ -185,7 +185,7 @@ variable "scsi_type" {
 
 variable "scsi_controller"{
   type        = number
-  default     = null
+  default     = 0
   # validation {
   #   condition     = var.scsi_controller < 4 && var.scsi_controller > -1
   #       error_message = "The scsi_controller must be between 0 and 3"

--- a/variables.tf
+++ b/variables.tf
@@ -170,6 +170,28 @@ variable "data_disk_datastore" {
   # }
 }
 
+variable "data_disk_scsi_controller" {
+  type        = list
+  default     = []
+  # validation {
+  #   condition     = max(var.data_disk_scsi_controller...) < 4 && max(var.data_disk_scsi_controller...) > -1
+  #       error_message = "The scsi_controller must be between 0 and 3"
+  # }
+}
+variable "scsi_type" {
+  type        = string
+  default     = ""
+}
+
+variable "scsi_controller"{
+  type        = number
+  default     = null
+  # validation {
+  #   condition     = var.scsi_controller < 4 && var.scsi_controller > -1
+  #       error_message = "The scsi_controller must be between 0 and 3"
+  # }
+}
+
 variable "thin_provisioned" {
   description = "If true, this disk is thin provisioned, with space for the file being allocated on an as-needed basis."
   type        = list


### PR DESCRIPTION
Adds the ability to select scsi_controllers per disk, this is done by calculating the unit_number. The limit of disks still stays at 15 due to how the unit_numbers are calculated here but in theory this could be adjusted.

[Official documentation](https://www.terraform.io/docs/providers/vsphere/r/virtual_machine.html#unit_number)
> unit_number - (Optional) The disk number on the SCSI bus. The maximum value for this setting is the value of scsi_controller_count times 15, minus 1 (so 14, 29, 44, and 59, for 1-4 controllers respectively). The default is 0, for which one disk must be set to. Duplicate unit numbers are not allowed. 