### PR TITLE
Rename thin_provisioned to data_disk prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ There are number of switches defined in the module, where you can use to enable 
 - You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
 - You can use `data_disk_size_gb = [20,30]` to add additional data disks (Supported in both Linux and Windows deployment)
   - Above switch will create two additional disk of capacity 10 and 30gb for the VM.
-  - You can include `thin_provisioned` switch to define disk type for each additional disk.
+  - You can include `data_disk_thin_provisioned` switch to define disk type for each additional disk.
 - You can use `windomain = "somedomain.com"` to join a windows server to AD domain.
   - Requires following additional variables
     - `domainuser` Domain account with necessary privileges to join a computer to the domain.
@@ -115,7 +115,7 @@ module "example-server-windowsvm-advanced" {
     "test"       = ["", "192.168.0.3"]
   }
   data_disk_size_gb = [10, 5] // Aditional Disk to be used
-  thin_provisioned  = ["true", "false"]
+  data_disk_thin_provisioned  = ["true", "false"]
   disk_datastore             = "vsanDatastore" // This will store Template disk in the defined disk_datastore
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"] // Datastores for additional data disks
   scsi_type                 = "lsilogic" // Other acceptable value "pvscsi"

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -57,7 +57,7 @@ module "example-server-linuxvm-withdatadisk" {
     "test"       = ["", "192.168.0.3"]
   }
   data_disk_size_gb = [10, 5] // Aditional Disk to be used
-  thin_provisioned  = ["true", "false"]
+  data_disk_thin_provisioned  = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   tags = {

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -42,7 +42,7 @@ module "example-server-linuxvm-advanced" {
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb = [10, 5] // Aditional Disks to be used
-  thin_provisioned  = ["true", "false"]
+  data_disk_thin_provisioned = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   tags = {

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -53,7 +53,7 @@ module "example-server-windowsvm-advanced" {
     "test"       = ["", "192.168.0.3"]
   }
   data_disk_size_gb = [10, 5] // Aditional Disks to be used
-  thin_provisioned  = ["true", "false"]
+  data_disk_thin_provisioned  = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   tags = {

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -62,7 +62,7 @@ module "example-server-windowsvm-advanced" {
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb = [10, 5] // Aditional Disks to be used
-  thin_provisioned  = ["true", "false"]
+  data_disk_thin_provisioned = ["true", "false"]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -213,7 +213,7 @@ resource "vsphere_virtual_machine" "Windows" {
       label            = "disk${terraform_disks.key + local.template_disk_count}"
       size             = var.data_disk_size_gb[terraform_disks.key]
       unit_number      = length(var.data_disk_scsi_controller) > 0 ? var.data_disk_scsi_controller[terraform_disks.key] * 15 + terraform_disks.key + (var.scsi_controller == var.data_disk_scsi_controller[terraform_disks.key] ? local.template_disk_count : 0) : terraform_disks.key + local.template_disk_count
-      thin_provisioned = var.thin_provisioned != null ? var.thin_provisioned[terraform_disks.key] : null
+      thin_provisioned = var.data_disk_thin_provisioned != null ? var.data_disk_thin_provisioned[terraform_disks.key] : null
       eagerly_scrub    = var.eagerly_scrub != null ? var.eagerly_scrub[terraform_disks.key] : null
       datastore_id     = length(var.data_disk_datastore) > 0 ? data.vsphere_datastore.data_disk_datastore[var.data_disk_datastore[terraform_disks.key]].id : null
     }

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ resource "vsphere_virtual_machine" "Linux" {
       label            = "disk${terraform_disks.key + local.template_disk_count}"
       size             = var.data_disk_size_gb[terraform_disks.key]
       unit_number      = length(var.data_disk_scsi_controller) > 0 ? var.data_disk_scsi_controller[terraform_disks.key] * 15 + terraform_disks.key + (var.scsi_controller == var.data_disk_scsi_controller[terraform_disks.key] ? local.template_disk_count : 0) : terraform_disks.key + local.template_disk_count
-      thin_provisioned = var.thin_provisioned != null ? var.thin_provisioned[terraform_disks.key] : null
+      thin_provisioned = var.data_disk_thin_provisioned != null ? var.data_disk_thin_provisioned[terraform_disks.key] : null
       eagerly_scrub    = var.eagerly_scrub != null ? var.eagerly_scrub[terraform_disks.key] : null
       datastore_id     = length(var.data_disk_datastore) > 0 ? data.vsphere_datastore.data_disk_datastore[var.data_disk_datastore[terraform_disks.key]].id : null
     }

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "scsi_controller"{
   # }
 }
 
-variable "thin_provisioned" {
+variable "data_disk_thin_provisioned" {
   description = "If true, this disk is thin provisioned, with space for the file being allocated on an as-needed basis."
   type        = list
   default     = null


### PR DESCRIPTION
Renamed thin_provisioned to data_disk_thin_provisioned.

This makes the variable clearer in usage definition.

Breaking change for people that already define thin_provisioned.