### PR TITLE
Depends on vm_depend before get data tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,14 +43,16 @@ data "vsphere_virtual_machine" "template" {
 }
 
 data "vsphere_tag_category" "category" {
-  count = var.tags != null ? length(var.tags) : 0
-  name  = keys(var.tags)[count.index]
+  count      = var.tags != null ? length(var.tags) : 0
+  name       = keys(var.tags)[count.index]
+  depends_on = [var.vm_depends_on]
 }
 
 data "vsphere_tag" "tag" {
   count       = var.tags != null ? length(var.tags) : 0
   name        = var.tags[keys(var.tags)[count.index]]
   category_id = "${data.vsphere_tag_category.category[count.index].id}"
+  depends_on  = [var.vm_depends_on]
 }
 
 locals {


### PR DESCRIPTION
# Summary
If the tag category and the tags itself are created by Terraform (outside of this project) the module will fail as the tags couldn't be read during startup.

# Behaviour
```hcl
data "vsphere_tag_category" "foo" {
  name = "foo"
}

resource "vsphere_tag" "bar" {
  name        = "bar"
  description = "bar"
  category_id = data.vsphere_tag_category.foo.id
}

module "example-server-linuxvm" {
  source        = "Terraform-VMWare-Modules/vm/vsphere"
  version       = "1.3.0"
  vmtemp        = "TemplateName"
  instances     = 1
  vmname        = "example-server-windows"
  vmrp          = "esxi/Resources"
  network_cards = ["Name of the Port Group in vSphere"]
  ipv4 = {
    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
  }
  dc        = "Datacenter"
  datastore = "Data Store name(use ds_cluster for datastore cluster)"
  tags = {
    "foo" = "bar"
  }
}
```

That leads to the following error:
```
Error: tag name "bar" not found in category ID "urn:vmomi:InventoryServiceCategory:e5998e59-9483-494b-a3d4-b4e5d797e7dc:GLOBAL"

  on .terraform/modules/example-server-linuxvm/main.tf line 50, in data "vsphere_tag" "tag":
  50: data "vsphere_tag" "tag" {
```