### PR TITLE
data lazy loading isn't a good idea.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,16 +43,14 @@ data "vsphere_virtual_machine" "template" {
 }
 
 data "vsphere_tag_category" "category" {
-  count      = var.tags != null ? length(var.tags) : 0
-  name       = keys(var.tags)[count.index]
-  depends_on = [var.vm_depends_on]
+  count = var.tags != null ? length(var.tags) : 0
+  name  = keys(var.tags)[count.index]
 }
 
 data "vsphere_tag" "tag" {
   count       = var.tags != null ? length(var.tags) : 0
   name        = var.tags[keys(var.tags)[count.index]]
   category_id = "${data.vsphere_tag_category.category[count.index].id}"
-  depends_on  = [var.vm_depends_on]
 }
 
 locals {
@@ -68,7 +66,7 @@ resource "vsphere_virtual_machine" "Linux" {
 
   resource_pool_id  = data.vsphere_resource_pool.pool.id
   folder            = var.vmfolder
-  tags              = data.vsphere_tag.tag[*].id
+  tags              = var.tag_ids != null ? var.tag_ids : data.vsphere_tag.tag[*].id
   custom_attributes = var.custom_attributes
   annotation        = var.annotation
   extra_config      = var.extra_config
@@ -163,7 +161,7 @@ resource "vsphere_virtual_machine" "Windows" {
 
   resource_pool_id  = data.vsphere_resource_pool.pool.id
   folder            = var.vmfolder
-  tags              = data.vsphere_tag.tag[*].id
+  tags              = var.tag_ids != null ? var.tag_ids : data.vsphere_tag.tag[*].id
   custom_attributes = var.custom_attributes
   annotation        = var.annotation
   extra_config      = var.extra_config

--- a/main.tf
+++ b/main.tf
@@ -43,14 +43,16 @@ data "vsphere_virtual_machine" "template" {
 }
 
 data "vsphere_tag_category" "category" {
-  count = var.tags != null ? length(var.tags) : 0
-  name  = keys(var.tags)[count.index]
+  count      = var.tags != null ? length(var.tags) : 0
+  name       = keys(var.tags)[count.index]
+  depends_on = [var.tag_depends_on]
 }
 
 data "vsphere_tag" "tag" {
   count       = var.tags != null ? length(var.tags) : 0
   name        = var.tags[keys(var.tags)[count.index]]
   category_id = "${data.vsphere_tag_category.category[count.index].id}"
+  depends_on  = [var.tag_depends_on]
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -90,8 +90,14 @@ variable "vmdns" {
 
 #Global Customization Variables
 variable "tags" {
-  description = "The names of any tags to attach to this resource. They shoud already exist"
+  description = "The names of any tags to attach to this resource. They must already exist."
   type        = map
+  default     = null
+}
+
+variable "tag_ids" {
+  description = "The ids of any tags to attach to this resource. They must already exist."
+  type        = list
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -351,3 +351,9 @@ variable "vm_depends_on" {
   type        = any
   default     = null
 }
+
+variable "tag_depends_on" {
+  description = "Add any external depend on module here like tag_depends_on = [vsphere_tag.foo.id]"
+  type        = any
+  default     = null
+}


### PR DESCRIPTION
# Summary
If data sources are loaded lazy, terraform will always ask for a change, even there is none, as it doesn't know the data objects.
Defining another variable tag_ids and add them directly to the vm instead of using a data source is the better way, if the tags are created with terraform.

# Behaviour
```
$ terraform apply
[...]
      ~ tags                                    = [
          - "urn:vmomi:InventoryServiceTag:abc:GLOBAL",
          - "urn:vmomi:InventoryServiceTag:def:GLOBAL",
        ] -> (known after apply)
[...]
Plan: 0 to add, 1 to change, 0 to destroy.
[...]
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```