### PR TITLE
Feature/boolean variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform vSphere Module
 
-![Terraform Version](https://img.shields.io/badge/Terraform-0.12.6-green.svg) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm/vsphere/) [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/releases) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) 
+![Terraform Version](https://img.shields.io/badge/Terraform-0.12.6-green.svg) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/Terraform-VMWare-Modules/vm/vsphere/) [![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/releases) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 For Virtual Machine Provisioning with (Linux/Windows) customization. Thanks to the new enhancements introduced in Terraform v0.12.6 this module include most of the advance features that are available in the resource `vsphere_virtual_machine`.
 
@@ -54,7 +54,7 @@ module "example-server-windowsvm" {
   source           = "Terraform-VMWare-Modules/vm/vsphere"
   version          = "X.X.X"
   vmtemp           = "TemplateName"
-  is_windows_image = "true"
+  is_windows_image = true
   instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
@@ -75,7 +75,7 @@ There are number of switches defined in the module, where you can use to enable 
 
 ### Main Feature Switches
 
-- You can use `is_windows_image = "true"` to set the customization type to Windows (By default it is set to Linux customization)
+- You can use `is_windows_image = true` to set the customization type to Windows (By default it is set to Linux customization)
 - You can use `data_disk_size_gb = [20,30]` to add additional data disks (Supported in both Linux and Windows deployment)
   - Above switch will create two additional disk of capacity 10 and 30gb for the VM.
   - You can include `thin_provisioned` switch to define disk type for each additional disk.
@@ -101,9 +101,9 @@ module "example-server-windowsvm-advanced" {
   ram_size               = 2096
   cpu_reservation        = 2000
   memory_reservation     = 2000
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-network"] #Assign multiple cards
@@ -114,7 +114,7 @@ module "example-server-windowsvm-advanced" {
     "test"       = ["", "192.168.0.3"]
   }
   data_disk_size_gb = [10, 5] // Aditional Disk to be used
-  thin_provisioned  = ["true", "false"]
+  thin_provisioned  = [true, false]
   disk_label                = ["tpl-disk-1"]
   data_disk_label           = ["label1", "label2"]
   disk_datastore             = "vsanDatastore" // This will store Template disk in the defined disk_datastore
@@ -129,12 +129,12 @@ module "example-server-windowsvm-advanced" {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"
   }
-  enable_disk_uuid = "true"
-  auto_logon       = "true"
+  enable_disk_uuid = true
+  auto_logon       = true
   run_once         = ["command01", "command02"] // You can also run Powershell commands
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
-  is_windows_image = "true"
+  is_windows_image = true
   firmware         = "efi"
   local_adminpass  = "Password@Strong"
 }

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -45,9 +45,9 @@ module "example-server-linuxvm-withdatadisk" {
   instances              = 2
   cpu_number             = 2
   ram_size               = 2096
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-network"]
@@ -64,7 +64,7 @@ module "example-server-linuxvm-withdatadisk" {
   data_disk_scsi_controller  = [0, 1]
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
-  thin_provisioned  = ["true", "false"]
+  thin_provisioned  = [true, false]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   network_type = ["vmxnet3", "vmxnet3"]

--- a/examples/linux/example-depend_on.tf
+++ b/examples/linux/example-depend_on.tf
@@ -26,9 +26,9 @@ module "example-server-linuxvm-advanced" {
   instances              = 2
   cpu_number             = 2
   ram_size               = 2096
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-network"]
@@ -45,7 +45,7 @@ module "example-server-linuxvm-advanced" {
   disk_datastore            = "vsanDatastore"
   data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = ["true", "false"]
+  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -25,9 +25,9 @@ module "example-server-linuxvm-advanced" {
   instances              = 2
   cpu_number             = 2
   ram_size               = 2096
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-network"]
@@ -44,7 +44,7 @@ module "example-server-linuxvm-advanced" {
   disk_datastore            = "vsanDatastore"
   data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = ["true", "false"]
+  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -41,9 +41,9 @@ module "example-server-windowsvm-advanced" {
   instances              = 2
   cpu_number             = 2
   ram_size               = 2096
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-netwrok"]
@@ -60,7 +60,7 @@ module "example-server-windowsvm-advanced" {
   data_disk_scsi_controller  = [0, 1]
   disk_datastore             = "vsanDatastore"
   data_disk_datastore        = ["vsanDatastore", "nfsDatastore"]
-  thin_provisioned  = ["true", "false"]
+  thin_provisioned  = [true, false]
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   network_type = ["vmxnet3", "vmxnet3"]
@@ -68,12 +68,12 @@ module "example-server-windowsvm-advanced" {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"
   }
-  enable_disk_uuid = "true"
-  auto_logon       = "true"
+  enable_disk_uuid = true
+  auto_logon       = true
   run_once         = ["mkdir c:\\admin", "echo runonce-test >> c:\\admin\\logs.txt", "powershell.exe \"New-Item C:\\test.txt\""]
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
-  is_windows_image = "true"
+  is_windows_image = true
   firmware         = "efi"
   local_adminpass  = "Password@Strong"
 }

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -3,7 +3,7 @@ module "example-server-windowsvm-withdatadisk" {
   source           = "Terraform-VMWare-Modules/vm/vsphere"
   version          = "Latest X.X.X"
   vmtemp           = "TemplateName"
-  is_windows_image = "true"
+  is_windows_image = true
   instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
@@ -19,7 +19,7 @@ module "example-server-windowsvm-withdatadisk" {
   source                = "Terraform-VMWare-Modules/vm/vsphere"
   version               = "1.1.0"
   vmtemp                = "TemplateName"
-  is_windows_image      = "true"
+  is_windows_image      = true
   windomain             = "Development.com"
   domain_admin_user     = "Domain admin user"
   domain_admin_password = "SomePassword"
@@ -45,9 +45,9 @@ module "example-server-windowsvm-advanced" {
   instances              = 2
   cpu_number             = 2
   ram_size               = 2096
-  cpu_hot_add_enabled    = "true"
-  cpu_hot_remove_enabled = "true"
-  memory_hot_add_enabled = "true"
+  cpu_hot_add_enabled    = true
+  cpu_hot_remove_enabled = true
+  memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
   network_cards          = ["VM Network", "test-network"]
@@ -64,7 +64,7 @@ module "example-server-windowsvm-advanced" {
   disk_datastore            = "vsanDatastore"
   data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
   data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = ["true", "false"]
+  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]
@@ -72,12 +72,12 @@ module "example-server-windowsvm-advanced" {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"
   }
-  enable_disk_uuid = "true"
-  auto_logon       = "true"
+  enable_disk_uuid = true
+  auto_logon       = true
   run_once         = ["command01", "powershell.exe \"New-Item C:\\test.txt\""] // You can also run Powershell commands
   orgname          = "Terraform-Module"
   workgroup        = "Module-Test"
-  is_windows_image = "true"
+  is_windows_image = true
   firmware         = "efi"
   local_adminpass  = "Password123"
 }

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ locals {
 
 // Cloning a Linux VM from a given template. Note: This is the default option!!
 resource "vsphere_virtual_machine" "Linux" {
-  count      = var.is_windows_image != "true" ? var.instances : 0
+  count      = var.is_windows_image ? 0 : var.instances
   depends_on = [var.vm_depends_on]
   name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
 
@@ -158,7 +158,7 @@ resource "vsphere_virtual_machine" "Linux" {
 }
 
 resource "vsphere_virtual_machine" "Windows" {
-  count      = var.is_windows_image == "true" ? var.instances : 0
+  count      = var.is_windows_image ? var.instances : 0
   depends_on = [var.vm_depends_on]
   name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -149,16 +149,19 @@ variable "num_cores_per_socket" {
 
 variable "cpu_hot_add_enabled" {
   description = "Allow CPUs to be added to this virtual machine while it is running."
+  type        = bool
   default     = null
 }
 
 variable "cpu_hot_remove_enabled" {
   description = "Allow CPUs to be removed to this virtual machine while it is running."
+  type        = bool
   default     = null
 }
 
 variable "memory_hot_add_enabled" {
   description = "Allow memory to be added to this virtual machine while it is running."
+  type        = bool
   default     = null
 }
 
@@ -247,6 +250,7 @@ variable "eagerly_scrub" {
 
 variable "enable_disk_uuid" {
   description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest."
+  type        = bool
   default     = null
 }
 
@@ -259,6 +263,7 @@ variable "network_type" {
 #Linux Customization Variables
 variable "hw_clock_utc" {
   description = "Tells the operating system that the hardware clock is set to UTC"
+  type        = bool
   default     = true
 }
 
@@ -271,6 +276,7 @@ variable "vmdomain" {
 #Windows Customization Variables
 variable "is_windows_image" {
   description = "Boolean flag to notify when the custom image is windows based."
+  type        = bool
   default     = false
 }
 
@@ -306,6 +312,7 @@ variable "orgname" {
 
 variable "auto_logon" {
   description = " Specifies whether or not the VM automatically logs on as Administrator. Default: false"
+  type = bool
   default     = null
 }
 
@@ -337,20 +344,20 @@ variable "full_name" {
 
 variable "wait_for_guest_net_routable" {
   description = "Controls whether or not the guest network waiter waits for a routable address. When false, the waiter does not wait for a default gateway, nor are IP addresses checked against any discovered default gateways as part of its success criteria. This property is ignored if the wait_for_guest_ip_timeout waiter is used."
-  default     = true
   type        = bool
+  default     = true
 }
 
 variable "wait_for_guest_ip_timeout" {
   description = "The amount of time, in minutes, to wait for an available guest IP address on this virtual machine. This should only be used if your version of VMware Tools does not allow the wait_for_guest_net_timeout waiter to be used. A value less than 1 disables the waiter."
-  default     = 0
   type        = number
+  default     = 0
 }
 
 variable "wait_for_guest_net_timeout" {
   description = "The amount of time, in minutes, to wait for an available IP address on this virtual machine's NICs. Older versions of VMware Tools do not populate this property. In those cases, this waiter can be disabled and the wait_for_guest_ip_timeout waiter can be used instead. A value less than 1 disables the waiter."
-  default     = 5
   type        = number
+  default     = 5
 }
 
 variable "vm_depends_on" {


### PR DESCRIPTION
Refactored variables, defined variables with an implicit `type = bool` if it expects a boolean value. Doing this users can really define variables with a boolean value of `true` or `false`. Currently the module was not working with real boolean values and it expected the bools to be strings. 

This is no breaking change since users can still place their boolean variables in quotes like this: `is_windows_image="true"` and it will keep working.

Also shortened the ternary operator to check if machine should be Linux or Windows.