### PR TITLE
Add advanced parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,8 @@ resource "vsphere_virtual_machine" "Linux" {
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
   wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
 
+  ignored_guest_ips = var.ignored_guest_ips
+
   dynamic "network_interface" {
     for_each = var.network_cards
     content {
@@ -155,6 +157,18 @@ resource "vsphere_virtual_machine" "Linux" {
       ipv4_gateway    = var.vmgateway
     }
   }
+
+  // Advanced options
+  hv_mode = var.hv_mode
+  ept_rvi_mode = var.ept_rvi_mode
+  nested_hv_enabled  = var.nested_hv_enabled
+  enable_logging = var.enable_logging
+  cpu_performance_counters_enabled = var.cpu_performance_counters_enabled
+  swap_placement_policy = var.swap_placement_policy
+  latency_sensitivity = var.latency_sensitivity
+
+  shutdown_wait_timeout = var.shutdown_wait_timeout
+  force_power_off = var.force_power_off
 }
 
 resource "vsphere_virtual_machine" "Windows" {
@@ -190,6 +204,8 @@ resource "vsphere_virtual_machine" "Windows" {
   wait_for_guest_net_routable = var.wait_for_guest_net_routable
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
   wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
+
+  ignored_guest_ips = var.ignored_guest_ips
 
   dynamic "network_interface" {
     for_each = var.network_cards
@@ -261,4 +277,16 @@ resource "vsphere_virtual_machine" "Windows" {
       ipv4_gateway    = var.vmgateway
     }
   }
+
+  // Advanced options
+  hv_mode = var.hv_mode
+  ept_rvi_mode = var.ept_rvi_mode
+  nested_hv_enabled  = var.nested_hv_enabled
+  enable_logging = var.enable_logging
+  cpu_performance_counters_enabled = var.cpu_performance_counters_enabled
+  swap_placement_policy = var.swap_placement_policy
+  latency_sensitivity = var.latency_sensitivity
+
+  shutdown_wait_timeout = var.shutdown_wait_timeout
+  force_power_off = var.force_power_off
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,29 +1,29 @@
 variable "vmname" {
-  description = "The name of the virtual machine used to deploy the vms"
+  description = "The name of the virtual machine used to deploy the vms."
   default     = "terraformvm"
 }
 
 variable "vmnamesuffix" {
-  description = "vmname suffix after numbered index coming from instance variable"
+  description = "vmname suffix after numbered index coming from instance variable."
   default     = ""
 }
 
 variable "vmnameliteral" {
-  description = "vmname without any suffix or Prefix, only to be used for single instances"
+  description = "vmname without any suffix or Prefix, only to be used for single instances."
   default     = ""
 }
 
 variable "vmtemp" {
-  description = "Name of the template available in the vSphere"
+  description = "Name of the template available in the vSphere."
 }
 
 variable "instances" {
-  description = "number of instances you want deploy from the template"
+  description = "number of instances you want deploy from the template."
   default     = 1
 }
 
 variable "cpu_number" {
-  description = "number of CPU (core per CPU) for the VM"
+  description = "number of CPU (core per CPU) for the VM."
   default     = 2
 }
 
@@ -34,7 +34,7 @@ variable "cpu_reservation" {
 
 
 variable "ram_size" {
-  description = "VM RAM size in megabytes"
+  description = "VM RAM size in megabytes."
   default     = 4096
 }
 
@@ -44,22 +44,22 @@ variable "network_cards" {
 }
 
 variable "ipv4" {
-  description = "host(VM) IP address in map format, support more than one IP. Should correspond to number of instances"
+  description = "host(VM) IP address in map format, support more than one IP. Should correspond to number of instances."
   type        = map
 }
 
 variable "ipv4submask" {
-  description = "ipv4 Subnet mask"
+  description = "ipv4 Subnet mask."
   type        = list
   default     = ["24"]
 }
 
 variable "dc" {
-  description = "Name of the datacenter you want to deploy the VM to"
+  description = "Name of the datacenter you want to deploy the VM to."
 }
 
 variable "vmrp" {
-  description = "Cluster resource pool that VM will be deployed to. you use following to choose default pool in the cluster (esxi1) or (Cluster)/Resources"
+  description = "Cluster resource pool that VM will be deployed to. you use following to choose default pool in the cluster (esxi1) or (Cluster)/Resources."
 }
 
 variable "ds_cluster" {
@@ -79,7 +79,7 @@ variable "vmfolder" {
 }
 
 variable "vmgateway" {
-  description = "VM gateway to set during provisioning"
+  description = "VM gateway to set during provisioning."
   default     = null
 }
 
@@ -108,7 +108,7 @@ variable "custom_attributes" {
 }
 
 variable "extra_config" {
-  description = "Extra configuration data for this virtual machine. Can be used to supply advanced parameters not normally in configuration, such as instance metadata.'disk.enableUUID', 'True'"
+  description = "Extra configuration data for this virtual machine. Can be used to supply advanced parameters not normally in configuration, such as instance metadata.'disk.enableUUID', 'True'."
   type        = map
   default     = null
 }
@@ -171,31 +171,31 @@ variable "memory_reservation" {
 }
 
 variable "disk_label" {
-  description = "Storage data disk labels"
+  description = "Storage data disk labels."
   type        = list
   default     = []
 }
 
 variable "data_disk_label" {
-  description = "Storage data disk labels"
+  description = "Storage data disk labels."
   type        = list
   default     = []
 }
 
 variable "data_disk_size_gb" {
-  description = "List of Storage data disk size"
+  description = "List of Storage data disk size."
   type        = list
   default     = []
 }
 
 variable "disk_datastore" {
-  description = "Define where the OS disk should be stored"
+  description = "Define where the OS disk should be stored."
   type        = string
   default     = ""
 }
 
 variable "data_disk_datastore" {
-  description = "Define where the data disk should be stored, should be equal to number of defined data disks"
+  description = "Define where the data disk should be stored, should be equal to number of defined data disks."
   type        = list
   default     = []
   # validation {
@@ -205,7 +205,7 @@ variable "data_disk_datastore" {
 }
 
 variable "data_disk_scsi_controller" {
-  description = "scsi_controller number for the data disk, should be equal to number of defined data disk"
+  description = "scsi_controller number for the data disk, should be equal to number of defined data disk."
   type        = list
   default     = []
   # validation {
@@ -215,19 +215,19 @@ variable "data_disk_scsi_controller" {
 }
 
 variable "scsi_bus_sharing" {
-  description = "scsi_bus_sharing mode, acceptable values physicalSharing,virtualSharing,noSharing"
+  description = "scsi_bus_sharing mode, acceptable values physicalSharing,virtualSharing,noSharing."
   type        = string
   default     = null
 }
 
 variable "scsi_type" {
-  description = "scsi_controller type, acceptable values lsilogic,pvscsi "
+  description = "scsi_controller type, acceptable values lsilogic,pvscsi."
   type        = string
   default     = ""
 }
 
 variable "scsi_controller" {
-  description = "scsi_controller number for the main OS disk"
+  description = "scsi_controller number for the main OS disk."
   type        = number
   default     = 0
   # validation {
@@ -255,20 +255,20 @@ variable "enable_disk_uuid" {
 }
 
 variable "network_type" {
-  description = "Define network type for each network interface"
+  description = "Define network type for each network interface."
   type        = list
   default     = null
 }
 
 #Linux Customization Variables
 variable "hw_clock_utc" {
-  description = "Tells the operating system that the hardware clock is set to UTC"
+  description = "Tells the operating system that the hardware clock is set to UTC."
   type        = bool
   default     = true
 }
 
 variable "vmdomain" {
-  description = "default VM domain for linux guest customization"
+  description = "default VM domain for linux guest customization."
   default     = "Development.com"
 }
 
@@ -281,7 +281,7 @@ variable "is_windows_image" {
 }
 
 variable "local_adminpass" {
-  description = "The administrator password for this virtual machine.(Required) when using join_windomain option"
+  description = "The administrator password for this virtual machine.(Required) when using join_windomain option."
   default     = null
 }
 
@@ -296,28 +296,28 @@ variable "windomain" {
 }
 
 variable "domain_admin_user" {
-  description = "Domain admin user to join the server to AD.(Required) when using join_windomain option"
+  description = "Domain admin user to join the server to AD.(Required) when using join_windomain option."
   default     = null
 }
 
 variable "domain_admin_password" {
-  description = "Doamin User pssword to join the server to AD.(Required) when using join_windomain option"
+  description = "Doamin User pssword to join the server to AD.(Required) when using join_windomain option."
   default     = null
 }
 
 variable "orgname" {
-  description = "Organization name for when joining windows server to AD"
+  description = "Organization name for when joining windows server to AD."
   default     = null
 }
 
 variable "auto_logon" {
-  description = " Specifies whether or not the VM automatically logs on as Administrator. Default: false"
+  description = " Specifies whether or not the VM automatically logs on as Administrator. Default: false."
   type = bool
   default     = null
 }
 
 variable "auto_logon_count" {
-  description = "Specifies how many times the VM should auto-logon the Administrator account when auto_logon is true. This should be set accordingly to ensure that all of your commands that run in run_once_command_list can log in to run"
+  description = "Specifies how many times the VM should auto-logon the Administrator account when auto_logon is true. This should be set accordingly to ensure that all of your commands that run in run_once_command_list can log in to run."
   default     = null
 }
 
@@ -327,7 +327,7 @@ variable "time_zone" {
 }
 
 variable "run_once" {
-  description = "List of Comamnd to run during first logon (Automatic login set to 1)"
+  description = "List of Comamnd to run during first logon (Automatic login set to 1)."
   type        = list(string)
   default     = null
 }
@@ -338,7 +338,7 @@ variable "productkey" {
 }
 
 variable "full_name" {
-  description = "The full name of the user of this virtual machine. This populates the user field in the general Windows system information. Default - Administrator"
+  description = "The full name of the user of this virtual machine. This populates the user field in the general Windows system information. Default - Administrator."
   default     = null
 }
 
@@ -360,14 +360,80 @@ variable "wait_for_guest_net_timeout" {
   default     = 5
 }
 
+variable "ignored_guest_ips" {
+  description = "List of IP addresses and CIDR networks to ignore while waiting for an available IP address using either of the waiters. Any IP addresses in this list will be ignored if they show up so that the waiter will continue to wait for a real IP address."
+  type        = list(string)
+  default     = []
+}
+
 variable "vm_depends_on" {
-  description = "Add any external depend on module here like vm_depends_on = [module.fw_core01.firewall]"
+  description = "Add any external depend on module here like vm_depends_on = [module.fw_core01.firewall]."
   type        = any
   default     = null
 }
 
 variable "tag_depends_on" {
-  description = "Add any external depend on module here like tag_depends_on = [vsphere_tag.foo.id]"
+  description = "Add any external depend on module here like tag_depends_on = [vsphere_tag.foo.id]."
   type        = any
+  default     = null
+}
+
+variable "hv_mode" {
+  description = "The (non-nested) hardware virtualization setting for this virtual machine. Can be one of hvAuto, hvOn, or hvOff."
+  type        = string
+  default     = null
+}
+
+variable "ept_rvi_mode" {
+  description = "The EPT/RVI (hardware memory virtualization) setting for this virtual machine."
+  type        = string
+  default     = null
+}
+
+variable "nested_hv_enabled" {
+  description = "Enable nested hardware virtualization on this virtual machine, facilitating nested virtualization in the guest."
+  type        = bool
+  default     = null
+}
+
+variable "enable_logging" {
+  description = "Enable logging of virtual machine events to a log file stored in the virtual machine directory."
+  type        = bool
+  default     = null
+}
+
+variable "cpu_performance_counters_enabled" {
+  description = "Enable CPU performance counters on this virtual machine."
+  type        = bool
+  default     = null
+}
+
+variable "swap_placement_policy" {
+  description = "The swap file placement policy for this virtual machine. Can be one of inherit, hostLocal, or vmDirectory."
+  type        = string
+  default     = null
+}
+
+variable "latency_sensitivity" {
+  description = "Controls the scheduling delay of the virtual machine. Use a higher sensitivity for applications that require lower latency, such as VOIP, media player applications, or applications that require frequent access to mouse or keyboard devices.Can be one of low, normal, medium, or high."
+  type        = string
+  default     = null
+}
+
+variable "shutdown_wait_timeout" {
+  description = "The amount of time, in minutes, to wait for a graceful guest shutdown when making necessary updates to the virtual machine. If force_power_off is set to true, the VM will be force powered-off after this timeout, otherwise an error is returned."
+  type        = string
+  default     = null
+}
+
+variable "migrate_wait_timeout" {
+  description = "The amount of time, in minutes, to wait for a graceful guest shutdown when making necessary updates to the virtual machine. If force_power_off is set to true, the VM will be force powered-off after this timeout, otherwise an error is returned."
+  type        = string
+  default     = null
+}
+
+variable "force_power_off" {
+  description = "If a guest shutdown failed or timed out while updating or destroying (see shutdown_wait_timeout), force the power-off of the virtual machine."
+  type        = bool
   default     = null
 }


### PR DESCRIPTION
I added advanced parameters which can be configured in vSphere for more advanced Terraform use cases.

Also added `ignored_guest_ips`. This is a list with a range of IPs in CIDR notation. Mainly added this because I was running into some issues when trying to create a Windows VM. When I configured a Windows VM with static IP addresses, the IP addresses where configured in the guest OS after the Terraform plan terminated. It always takes a little longer for the static IPs to be properly configured (running DHCP server in the network where the VMs are spun up), this gave issues in the windows guest IP output and gave back the DHCP adresses instead of the static configured IPs.

The static IP issue can be avoided by assigning the DHCP range to the `ignored_guest_ips` parameter.
e.g. `ignored_guest_ips=["10.10.22.0/23"]`, this will ignore all IPs from `10.10.22.0-10.10.23.255`.

No breaking change.