### PR TITLE
Feature/override disk size

### DIFF
--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -75,6 +75,46 @@ module "example-server-linuxvm-withdatadisk" {
 }
 ```
 
+### Example of template disk size configuration
+
+Below example will deploy an instance of a virtual machine from a linux template. The virtual machine makes use of a template that is 16GB in size originally but is expanded to 32GB.
+To override the disks configured in the virtual machine template add the `disk_size_gb` variable (list), and configure the disk sizes as integers to match the templates amount of disks.
+
+```hcl
+module "example-server-linuxvm-override-template-size" {
+  source                 = "Terraform-VMWare-Modules/vm/vsphere"
+  version                = "Latest X.X.X"
+  dc                     = "Datacenter"
+  vmrp                   = "cluster/Resources"
+  vmfolder               = "Cattle"
+  ds_cluster             = "Datastore Cluster"
+  vmtemp                 = "TemplateName"
+  instances              = 2
+  cpu_number             = 2
+  ram_size               = 2096
+  vmname                 = "AdvancedVM"
+  vmdomain               = "somedomain.com"
+  network_cards          = ["VM Network"]
+  ipv4submask            = ["24"]
+  ipv4 = {
+    "VM Network" = ["192.168.0.4"]
+  }
+  disk_size_gb = [32] // Value to override the template disk size (add x amount of values to match the amount of disks in the template)
+  disk_label                 = ["tpl-disk-1"]
+  data_disk_size_gb = [10] // Aditional Disk to be used
+  data_disk_label            = ["label1"]
+  disk_datastore             = "vsanDatastore"
+  data_disk_datastore        = ["vsanDatastore"]
+  thin_provisioned  = [true]
+  vmdns             = ["192.168.0.2"]
+  vmgateway         = "192.168.0.1"
+  network_type = ["vmxnet3"]
+  tags = {
+    "terraform-test-category"    = "terraform-test-tag"
+  }
+}
+```
+
 ## Authors
 
 Originally created by [Arman Keyoumarsi](https://github.com/Arman-Keyoumarsi)

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -31,7 +31,7 @@ module "example-server-windowsvm-withdatadisk" {
 
 ```hcl
 module "example-server-windowsvm-advanced" {
-   source                 = "Terraform-VMWare-Modules/vm/vsphere"
+  source                 = "Terraform-VMWare-Modules/vm/vsphere"
   version                = "Latest X.X.X"
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
@@ -67,6 +67,54 @@ module "example-server-windowsvm-advanced" {
   tags = {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"
+  }
+  enable_disk_uuid = true
+  auto_logon       = true
+  run_once         = ["mkdir c:\\admin", "echo runonce-test >> c:\\admin\\logs.txt", "powershell.exe \"New-Item C:\\test.txt\""]
+  orgname          = "Terraform-Module"
+  workgroup        = "Module-Test"
+  is_windows_image = true
+  firmware         = "efi"
+  local_adminpass  = "Password@Strong"
+}
+```
+
+### Example of template disk size configuration
+
+Below example will deploy an instance of a virtual machine from a Windows template. The virtual machine makes use of a template that is 16GB in size originally but is expanded to 32GB.
+To override the disks configured in the virtual machine template add the `disk_size_gb` variable (list), and configure the disk sizes as integers to match the templates amount of disks.
+
+```hcl
+module "example-server-windowsvm-override-template-size" {
+  source                 = "Terraform-VMWare-Modules/vm/vsphere"
+  version                = "Latest X.X.X"
+  dc                     = "Datacenter"
+  vmrp                   = "cluster/Resources"
+  vmfolder               = "Cattle"
+  ds_cluster             = "Datastore Cluster"
+  vmtemp                 = "TemplateName"
+  instances              = 2
+  cpu_number             = 2
+  ram_size               = 2096
+  vmname                 = "AdvancedVM"
+  vmdomain               = "somedomain.com"
+  network_cards          = ["VM Network"]
+  ipv4submask            = ["24"]
+  ipv4 = {
+    "VM Network" = ["192.168.0.4"]
+  }
+  disk_size_gb = [32] // Value to override the template disk size (add x amount of values to match the amount of disks in the template)
+  disk_label                 = ["tpl-disk-1"]
+  data_disk_size_gb = [10] // Aditional Disk to be used
+  data_disk_label            = ["label1"]
+  disk_datastore             = "vsanDatastore"
+  data_disk_datastore        = ["vsanDatastore"]
+  thin_provisioned  = [true]
+  vmdns             = ["192.168.0.2"]
+  vmgateway         = "192.168.0.1"
+  network_type = ["vmxnet3"]
+  tags = {
+    "terraform-test-category"    = "terraform-test-tag"
   }
   enable_disk_uuid = true
   auto_logon       = true

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "vsphere_virtual_machine" "Linux" {
     iterator = template_disks
     content {
       label            = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      size             = var.override_template_disk_size != null ? var.override_template_disk_size[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
       unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "vsphere_virtual_machine" "Linux" {
     iterator = template_disks
     content {
       label            = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size             = var.override_template_disk_size != null ? var.override_template_disk_size[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      size             = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
       unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
@@ -221,7 +221,7 @@ resource "vsphere_virtual_machine" "Windows" {
     iterator = template_disks
     content {
       label            = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size             = data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      size             = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
       unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
       thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
       eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,12 @@ variable "data_disk_size_gb" {
   default     = []
 }
 
+variable "override_template_disk_size" {
+  description = "List of disk sizes to override template disk size."
+  type = list
+  default = null
+}
+
 variable "disk_datastore" {
   description = "Define where the OS disk should be stored."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -188,7 +188,7 @@ variable "data_disk_size_gb" {
   default     = []
 }
 
-variable "override_template_disk_size" {
+variable "disk_size_gb" {
   description = "List of disk sizes to override template disk size."
   type = list
   default = null


### PR DESCRIPTION
Added a variable `disk_size_gb` to be able to override a templates disk sizes. Added as a list so if a template has multiple disks this still works.