### PR TITLE
Wac/use map 4 disk

### DIFF
--- a/examples/linux/example-depend_on.tf
+++ b/examples/linux/example-depend_on.tf
@@ -38,14 +38,24 @@ module "example-server-linuxvm-advanced" {
     "test"       = ["", "192.168.0.3"]
   }
   disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
   scsi_type                 = "lsilogic" # "pvscsi"
-  scsi_controller           = 0
-  data_disk_scsi_controller = [0, 1]
+  scsi_controller           = 1
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
+  data_disk = {
+    disk1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+    },
+    disk2 = {
+      size_gb = 15,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+    }
+    disk3 = {
+      size_gb = 20,
+      data_disk_datastore = "nfsDatastore"
+    }
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -37,14 +37,24 @@ module "example-server-linuxvm-advanced" {
     "test"       = ["", "192.168.0.3"]
   }
   disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
   scsi_type                 = "lsilogic" # "pvscsi"
   scsi_controller           = 0
-  data_disk_scsi_controller = [0, 1]
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
+  data_disk = {
+    disk1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+    },
+    disk2 = {
+      size_gb = 15,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+    }
+    disk3 = {
+      size_gb = 20,
+      data_disk_datastore = "nfsDatastore"
+    } 
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -60,11 +60,22 @@ module "example-server-windowsvm-advanced" {
   data_disk_label           = ["label1", "label2"]
   scsi_type                 = "lsilogic" # "pvscsi"
   scsi_controller           = 0
-  data_disk_scsi_controller = [0, 3]
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
+  data_disk = {
+    disk1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+    },
+    disk2 = {
+      size_gb = 15,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+    }
+    disk3 = {
+      size_gb = 20,
+      data_disk_datastore = "nfsDatastore"
+    }
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
   network_type              = ["vmxnet3", "vmxnet3"]

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "vsphere_virtual_machine" "Linux" {
   guest_id               = data.vsphere_virtual_machine.template.guest_id
   scsi_bus_sharing       = var.scsi_bus_sharing
   scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
-  scsi_controller_count  = max(max(flatten([
+  scsi_controller_count  = max(max(0, flatten([
                             for item in values(var.data_disk): [
                               for elem, val in item:
                                 elem == "data_disk_scsi_controller"? val : 0

--- a/variables.tf
+++ b/variables.tf
@@ -176,17 +176,13 @@ variable "disk_label" {
   default     = []
 }
 
-variable "data_disk_label" {
-  description = "Storage data disk labels."
-  type        = list
-  default     = []
+variable "data_disk" {
+  description = "Storage data disk parameters"
+  type        = map(map(string))
+  default     = {}
+
 }
 
-variable "data_disk_size_gb" {
-  description = "List of Storage data disk size."
-  type        = list
-  default     = []
-}
 
 variable "disk_datastore" {
   description = "Define where the OS disk should be stored."
@@ -204,15 +200,6 @@ variable "data_disk_datastore" {
   # }
 }
 
-variable "data_disk_scsi_controller" {
-  description = "scsi_controller number for the data disk, should be equal to number of defined data disk."
-  type        = list
-  default     = []
-  # validation {
-  #   condition     = max(var.data_disk_scsi_controller...) < 4 && max(var.data_disk_scsi_controller...) > -1
-  #       error_message = "The scsi_controller must be between 0 and 3"
-  # }
-}
 
 variable "scsi_bus_sharing" {
   description = "scsi_bus_sharing mode, acceptable values physicalSharing,virtualSharing,noSharing."
@@ -236,17 +223,6 @@ variable "scsi_controller" {
   # }
 }
 
-variable "thin_provisioned" {
-  description = "If true, this disk is thin provisioned, with space for the file being allocated on an as-needed basis."
-  type        = list
-  default     = null
-}
-
-variable "eagerly_scrub" {
-  description = "if set to true, the disk space is zeroed out on VM creation. This will delay the creation of the disk or virtual machine. Cannot be set to true when thin_provisioned is true."
-  type        = list
-  default     = null
-}
 
 variable "enable_disk_uuid" {
   description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest."


### PR DESCRIPTION
The Idea is to use map instead of list for disk block definition 
```hcl
data_disk = {
    disk1 = {
      size_gb = 5,
      thin_provisioned = false
    },
    disk2 = {
      size_gb = 10,
      thin_provisioned = true
    }
}
```

Using Map will let users to remove/change disk on a deployed instance, without having to destroy all disks,.
#44 
