### PR TITLE
Use Map for additional data disk and for network interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ module "example-server-linuxvm" {
   instances     = 1
   vmname        = "example-server-linux"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -55,12 +56,12 @@ module "example-server-windowsvm" {
   version          = "X.X.X"
   vmtemp           = "TemplateName"
   is_windows_image = true
-  instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
-  network_cards    = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create Empty list for each instance
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -96,7 +97,6 @@ module "example-server-windowsvm-advanced" {
   vmfolder               = "Cattle"
   ds_cluster             = "Datastore Cluster" #You can use datastore variable instead
   vmtemp                 = "TemplateName"
-  instances              = 2
   cpu_number             = 2
   ram_size               = 2096
   cpu_reservation        = 2000
@@ -106,23 +106,32 @@ module "example-server-windowsvm-advanced" {
   memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-network"] #Assign multiple cards
-  network_type              = ["vmxnet3", "vmxnet3"]
-  ipv4submask            = ["24", "8"]
-  ipv4 = { #assign IPs per card
-    "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
-    "test"       = ["", "192.168.0.3"]
+  network_cards          = {
+    "VM Network" = {
+      ipv4 = "192.168.0.4"
+      ipv4submask = "24"
+      type = "vmxnet3"
+    }
   }
-  data_disk_size_gb = [10, 5] // Aditional Disk to be used
-  thin_provisioned  = [true, false]
-  disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
+  data_disk = {
+    label1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+      data_disk_datastore = "vsanDatastore"
+    },
+    disk2 = {
+      label2 = 5,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+      data_disk_datastore = "nfsDatastore"
+    }
+  }
+
   disk_datastore             = "vsanDatastore" // This will store Template disk in the defined disk_datastore
-  data_disk_datastore        = ["vsanDatastore", "nfsDatastore"] // Datastores for additional data disks
   scsi_bus_sharing          = "physicalSharing" // The modes are physicalSharing, virtualSharing, and noSharing
   scsi_type                 = "lsilogic" // Other acceptable value "pvscsi"
   scsi_controller           = 0 // This will assign OS disk to controller 0
-  data_disk_scsi_controller = [0, 1] // This will create a new controller and assign second data disk to controller 1
   vmdns             = ["192.168.0.2", "192.168.0.1"]
   vmgateway         = "192.168.0.1"
   tags = {

--- a/examples/linux/example-depend_on.tf
+++ b/examples/linux/example-depend_on.tf
@@ -3,13 +3,13 @@ module "example-server-linuxvm" {
   source        = "Terraform-VMWare-Modules/vm/vsphere"
   version       = "Latest X.X.X"
   vmtemp        = "TemplateName"
-  instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
-  }
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
+    }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
 }
@@ -23,7 +23,6 @@ module "example-server-linuxvm-advanced" {
   vmfolder               = "Cattle"
   ds_cluster             = "Datastore Cluster"
   vmtemp                 = "TemplateName"
-  instances              = 2
   cpu_number             = 2
   ram_size               = 2096
   cpu_hot_add_enabled    = true
@@ -31,24 +30,32 @@ module "example-server-linuxvm-advanced" {
   memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-network"]
-  ipv4submask            = ["24", "8"]
-  ipv4 = {
-    "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP
-    "test"       = ["", "192.168.0.3"]
+  network_cards          = {
+    "VM Network" = {
+      ipv4 = "192.168.0.4"
+      ipv4submask = "24"
+      type = "vmxnet3"
+    }
   }
-  disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
+  data_disk = {
+    label1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+      data_disk_datastore = "vsanDatastore"
+    },
+    disk2 = {
+      label2 = 5,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+      data_disk_datastore = "nfsDatastore"
+    }
+  }
   scsi_type                 = "lsilogic" # "pvscsi"
   scsi_controller           = 0
-  data_disk_scsi_controller = [0, 1]
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
-  network_type              = ["vmxnet3", "vmxnet3"]
   tags = {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"

--- a/examples/linux/main.tf
+++ b/examples/linux/main.tf
@@ -3,12 +3,12 @@ module "example-server-linuxvm" {
   source        = "Terraform-VMWare-Modules/vm/vsphere"
   version       = "Latest X.X.X"
   vmtemp        = "TemplateName"
-  instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network_cards = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -22,7 +22,6 @@ module "example-server-linuxvm-advanced" {
   vmfolder               = "Cattle"
   ds_cluster             = "Datastore Cluster"
   vmtemp                 = "TemplateName"
-  instances              = 2
   cpu_number             = 2
   ram_size               = 2096
   cpu_hot_add_enabled    = true
@@ -30,24 +29,32 @@ module "example-server-linuxvm-advanced" {
   memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-network"]
-  ipv4submask            = ["24", "8"]
-  ipv4 = {
-    "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second set to DHCP
-    "test"       = ["", "192.168.0.3"]
+  network_cards          = {
+    "VM Network" = {
+      ipv4 = "192.168.0.4"
+      ipv4submask = "24"
+      type = "vmxnet3"
+    }
   }
-  disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
+  data_disk = {
+    label1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+      data_disk_datastore = "vsanDatastore"
+    },
+    disk2 = {
+      label2 = 5,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+      data_disk_datastore = "nfsDatastore"
+    }
+  }
   scsi_type                 = "lsilogic" # "pvscsi"
   scsi_controller           = 0
-  data_disk_scsi_controller = [0, 1]
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
-  network_type              = ["vmxnet3", "vmxnet3"]
   tags = {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"

--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -4,12 +4,12 @@ module "example-server-windowsvm-withdatadisk" {
   version          = "Latest X.X.X"
   vmtemp           = "TemplateName"
   is_windows_image = true
-  instances        = 1
   vmname           = "example-server-windows"
   vmrp             = "esxi/Resources"
-  network_cards    = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -23,12 +23,12 @@ module "example-server-windowsvm-withdatadisk" {
   windomain             = "Development.com"
   domain_admin_user     = "Domain admin user"
   domain_admin_password = "SomePassword"
-  instances             = 1
   vmname                = "example-server-windows"
   vmrp                  = "esxi/Resources"
-  network_cards         = ["Name of the Port Group in vSphere"]
-  ipv4 = {
-    "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
+  network_cards = {
+    "Name of the Port Group in vSphere" = {
+      ipv4 = "10.0.0.1" # To use DHCP create empty string
+    }
   }
   dc        = "Datacenter"
   datastore = "Data Store name(use ds_cluster for datastore cluster)"
@@ -42,7 +42,6 @@ module "example-server-windowsvm-advanced" {
   vmfolder               = "Cattle"
   ds_cluster             = "Datastore Cluster"
   vmtemp                 = "TemplateName"
-  instances              = 2
   cpu_number             = 2
   ram_size               = 2096
   cpu_hot_add_enabled    = true
@@ -50,24 +49,32 @@ module "example-server-windowsvm-advanced" {
   memory_hot_add_enabled = true
   vmname                 = "AdvancedVM"
   vmdomain               = "somedomain.com"
-  network_cards          = ["VM Network", "test-network"]
-  ipv4submask            = ["24", "8"]
-  ipv4 = {
-    "VM Network" = ["192.168.0.4", ""] // Here the first instance will use Static Ip and Second DHCP
-    "test"       = ["", "192.168.0.3"]
+  network_cards          = {
+    "VM Network" = {
+      ipv4 = "192.168.0.4"
+      ipv4submask = "24"
+      type = "vmxnet3"
+    }
   }
-  disk_label                = ["tpl-disk-1"]
-  data_disk_label           = ["label1", "label2"]
+  data_disk = {
+    label1 = {
+      size_gb = 10,
+      thin_provisioned = false
+      data_disk_scsi_controller = 0
+      data_disk_datastore = "vsanDatastore"
+    },
+    disk2 = {
+      label2 = 5,
+      thin_provisioned = true
+      data_disk_scsi_controller = 1
+      data_disk_datastore = "nfsDatastore"
+    }
+  }
   scsi_type                 = "lsilogic" # "pvscsi"
   scsi_controller           = 0
-  data_disk_scsi_controller = [0, 3]
   disk_datastore            = "vsanDatastore"
-  data_disk_datastore       = ["vsanDatastore", "nfsDatastore"]
-  data_disk_size_gb         = [10, 5] // Aditional Disks to be used
-  thin_provisioned          = [true, false]
   vmdns                     = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
-  network_type              = ["vmxnet3", "vmxnet3"]
   tags = {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"

--- a/variables.tf
+++ b/variables.tf
@@ -38,21 +38,11 @@ variable "ram_size" {
   default     = 4096
 }
 
-variable "network_cards" {
-  description = ""
-  type        = list(string)
+variable network_cards {
+  description = "network card definition"
+  type        = map(map(string))
 }
 
-variable "ipv4" {
-  description = "host(VM) IP address in map format, support more than one IP. Should correspond to number of instances."
-  type        = map
-}
-
-variable "ipv4submask" {
-  description = "ipv4 Subnet mask."
-  type        = list
-  default     = ["24"]
-}
 
 variable "dc" {
   description = "Name of the datacenter you want to deploy the VM to."
@@ -170,28 +160,17 @@ variable "memory_reservation" {
   default     = null
 }
 
-variable "disk_label" {
-  description = "Storage data disk labels."
-  type        = list
-  default     = []
-}
+variable "data_disk" {
+  description = "Storage data disk parameters"
+  type        = map(map(string))
+  default     = {}
 
-variable "data_disk_label" {
-  description = "Storage data disk labels."
-  type        = list
-  default     = []
-}
-
-variable "data_disk_size_gb" {
-  description = "List of Storage data disk size."
-  type        = list
-  default     = []
 }
 
 variable "disk_size_gb" {
   description = "List of disk sizes to override template disk size."
-  type = list
-  default = null
+  type        = list
+  default     = null
 }
 
 variable "disk_datastore" {
@@ -210,15 +189,6 @@ variable "data_disk_datastore" {
   # }
 }
 
-variable "data_disk_scsi_controller" {
-  description = "scsi_controller number for the data disk, should be equal to number of defined data disk."
-  type        = list
-  default     = []
-  # validation {
-  #   condition     = max(var.data_disk_scsi_controller...) < 4 && max(var.data_disk_scsi_controller...) > -1
-  #       error_message = "The scsi_controller must be between 0 and 3"
-  # }
-}
 
 variable "scsi_bus_sharing" {
   description = "scsi_bus_sharing mode, acceptable values physicalSharing,virtualSharing,noSharing."
@@ -242,17 +212,6 @@ variable "scsi_controller" {
   # }
 }
 
-variable "thin_provisioned" {
-  description = "If true, this disk is thin provisioned, with space for the file being allocated on an as-needed basis."
-  type        = list
-  default     = null
-}
-
-variable "eagerly_scrub" {
-  description = "if set to true, the disk space is zeroed out on VM creation. This will delay the creation of the disk or virtual machine. Cannot be set to true when thin_provisioned is true."
-  type        = list
-  default     = null
-}
 
 variable "enable_disk_uuid" {
   description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest."
@@ -318,7 +277,7 @@ variable "orgname" {
 
 variable "auto_logon" {
   description = " Specifies whether or not the VM automatically logs on as Administrator. Default: false."
-  type = bool
+  type        = bool
   default     = null
 }
 


### PR DESCRIPTION
The Idea is to use map instead of list for disk block definition
```hcl
data_disk = {
    disk1 = {
      size_gb = 5,
      thin_provisioned = false
    },
    disk2 = {
      size_gb = 10,
      thin_provisioned = true
    }
}
````
Using Map will let users to remove/change disk on a deployed instance, without having to destroy all disks,.
#44
Some for network interface : 
```hcl
network_cards   = {
    "VM Network" = {
      ipv4 = "192.168.0.4"
      ipv4submask = "24"
      type = "vmxnet3"
    }
  }
```