### PR TITLE
Add advanced machine name configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-# ChanegLog
+# ChangeLog
 
 ## v2.0.0
+
 __New Variables__
+
 ```hcl
 variable "network" {
   description = "Define PortGroup and IPs for each VM"
@@ -14,6 +16,7 @@ variable "data_disk" {
   default     = {}
 }
 ```
+
 __Removed varsiables__
 
 ```hcl

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ locals {
 resource "vsphere_virtual_machine" "Linux" {
   count      = var.is_windows_image ? 0 : var.instances
   depends_on = [var.vm_depends_on]
-  name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+  name = var.vmnameliteral != "" ? var.vmnameliteral : length(var.vmname) > 1 ? "${var.vmname[count.index]}${var.vmnamesuffix}" : "${var.vmname[0]}${count.index+1}${var.vmnamesuffix}"
 
   resource_pool_id  = data.vsphere_resource_pool.pool.id
   folder            = var.vmfolder
@@ -136,7 +136,7 @@ resource "vsphere_virtual_machine" "Linux" {
 
     customize {
       linux_options {
-        host_name    = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+        host_name    = var.vmnameliteral != "" ? var.vmnameliteral : length(var.vmname) > 1 ? "${var.vmname[count.index]}${var.vmnamesuffix}" : "${var.vmname[0]}${count.index+1}${var.vmnamesuffix}"
         domain       = var.vmdomain
         hw_clock_utc = var.hw_clock_utc
       }
@@ -170,7 +170,7 @@ resource "vsphere_virtual_machine" "Linux" {
 resource "vsphere_virtual_machine" "Windows" {
   count      = var.is_windows_image ? var.instances : 0
   depends_on = [var.vm_depends_on]
-  name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+  name       = var.vmnameliteral != "" ? var.vmnameliteral : length(var.vmname) > 1 ? "${var.vmname[count.index]}${var.vmnamesuffix}" : "${var.vmname[0]}${count.index+1}${var.vmnamesuffix}"
 
   resource_pool_id  = data.vsphere_resource_pool.pool.id
   folder            = var.vmfolder
@@ -249,7 +249,7 @@ resource "vsphere_virtual_machine" "Windows" {
 
     customize {
       windows_options {
-        computer_name         = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+        computer_name         = var.vmnameliteral != "" ? var.vmnameliteral : length(var.vmname) > 1 ? "${var.vmname[count.index]}${var.vmnamesuffix}" : "${var.vmname[0]}${count.index+1}${var.vmnamesuffix}"
         admin_password        = var.local_adminpass
         workgroup             = var.workgroup
         join_domain           = var.windomain

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,8 @@ variable "storage_policy_id" {
 ###########################################
 variable "vmname" {
   description = "The name of the virtual machine used to deploy the vms."
-  default     = "terraformvm"
+  type = list(string)
+  default     = ["terraform-vm"]
 }
 
 variable "vmnamesuffix" {


### PR DESCRIPTION
Created more advanced option to set vmnames, in the new code a list is being used, this makes it possible to set a specific vmname for each machine. This feature was needed by one of our customers. Only big change is that the vmname variable is no longer a string but a list of strings.