### PR TITLE
Update docs from ds_cluster to datastore_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module "example-server-linuxvm" {
   }
   vmgateway         = "10.13.113.1"
   dc        = "Datacenter"
-  datastore = "Data Store name(use ds_cluster for datastore cluster)"
+  datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
 
 ```
@@ -80,7 +80,7 @@ module "example-server-windowsvm-advanced" {
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources" #Works with ESXi/Resources
   vmfolder               = "Cattle"
-  ds_cluster             = "Datastore Cluster" #You can use datastore variable instead
+  datastore_cluster      = "Datastore Cluster" #You can use datastore variable instead
   vmtemp                 = "TemplateName"
   instances              = 2
   vmname                 = "AdvancedVM"

--- a/examples/example-Windows-data_disk.tf
+++ b/examples/example-Windows-data_disk.tf
@@ -1,14 +1,14 @@
 module "example-server-windowsvm-advanced" {
-  source     = "Terraform-VMWare-Modules/vm/vsphere"
-  version    = "X.X.X"
-  dc         = "Datacenter"
-  vmrp       = "cluster/Resources" #Works with ESXi/Resources
-  vmfolder   = "Cattle"
-  ds_cluster = "Datastore Cluster" #You can use datastore variable instead
-  vmtemp     = "TemplateName"
-  instances  = 2
-  vmname     = "AdvancedVM"
-  vmdomain   = "somedomain.com"
+  source            = "Terraform-VMWare-Modules/vm/vsphere"
+  version           = "X.X.X"
+  dc                = "Datacenter"
+  vmrp              = "cluster/Resources" #Works with ESXi/Resources
+  vmfolder          = "Cattle"
+  datastore_cluster = "Datastore Cluster" #You can use datastore variable instead
+  vmtemp            = "TemplateName"
+  instances         = 2
+  vmname            = "AdvancedVM"
+  vmdomain          = "somedomain.com"
   network = {
     "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
   }

--- a/examples/example-linux-Netwrok.tf
+++ b/examples/example-linux-Netwrok.tf
@@ -5,7 +5,7 @@ module "example-server-linuxvm-advanced" {
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
-  ds_cluster             = "Datastore Cluster"
+  datastore_cluster      = "Datastore Cluster"
   vmtemp                 = "TemplateName"
   instances              = 2
   cpu_number             = 2

--- a/examples/example-linux-depend_on.tf
+++ b/examples/example-linux-depend_on.tf
@@ -11,7 +11,7 @@ module "example-server-linuxvm" {
     "Name of the Port Group in vSphere" = ["10.0.0.1"] # To use DHCP create empty string for each instance
   }
   dc        = "Datacenter"
-  datastore = "Data Store name(use ds_cluster for datastore cluster)"
+  datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
 // Example of Linux VM with more Advanced Features
 module "example-server-linuxvm-advanced" {
@@ -21,7 +21,7 @@ module "example-server-linuxvm-advanced" {
   dc                     = "Datacenter"
   vmrp                   = "cluster/Resources"
   vmfolder               = "Cattle"
-  ds_cluster             = "Datastore Cluster"
+  datastore_cluster      = "Datastore Cluster"
   vmtemp                 = "TemplateName"
   instances              = 2
   cpu_number             = 2


### PR DESCRIPTION
Update readme and examples from ds_cluster to datastore_cluster as referenced in variables.tf

```
#Data Disk section
variable "datastore_cluster" {
  description = "Datastore cluster to deploy the VM."
  default     = ""
}
```