### PR TITLE
Use format for VM names

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ module "example-server-linuxvm" {
 
 ```
 
+## VM name
+
+`vmname` is the format, with index coming from instance number, used to name the deployed VMs (see [`format` function](https://www.terraform.io/docs/language/functions/format.html)) (e.g. `terraform-vm-%02d`).
+
+When only one VM is requested, `vmname` is simply the name of the deployed VM.
+
 ## Advance Usage
 
 There are number of switches defined in the module, where you can use to enable different features for VM provisioning.

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ locals {
 resource "vsphere_virtual_machine" "Linux" {
   count      = var.is_windows_image ? 0 : var.instances
   depends_on = [var.vm_depends_on]
-  name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+  name       = var.instances == 1 ? var.vmname : format(var.vmname, count.index + 1)
 
   resource_pool_id        = data.vsphere_resource_pool.pool.id
   folder                  = var.vmfolder
@@ -137,7 +137,7 @@ resource "vsphere_virtual_machine" "Linux" {
 
     customize {
       linux_options {
-        host_name    = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+        host_name    = var.instances == 1 ? var.vmname : format(var.vmname, count.index + 1)
         domain       = var.vmdomain
         hw_clock_utc = var.hw_clock_utc
       }
@@ -171,7 +171,7 @@ resource "vsphere_virtual_machine" "Linux" {
 resource "vsphere_virtual_machine" "Windows" {
   count      = var.is_windows_image ? var.instances : 0
   depends_on = [var.vm_depends_on]
-  name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+  name       = var.instances == 1 ? var.vmname : format(var.vmname, count.index + 1)
 
   resource_pool_id        = data.vsphere_resource_pool.pool.id
   folder                  = var.vmfolder
@@ -251,7 +251,7 @@ resource "vsphere_virtual_machine" "Windows" {
 
     customize {
       windows_options {
-        computer_name         = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+        computer_name         = var.instances == 1 ? var.vmname : format(var.vmname, count.index + 1)
         admin_password        = var.local_adminpass
         workgroup             = var.workgroup
         join_domain           = var.windomain

--- a/variables.tf
+++ b/variables.tf
@@ -87,18 +87,8 @@ variable "storage_policy_id" {
 
 ###########################################
 variable "vmname" {
-  description = "The name of the virtual machine used to deploy the vms."
-  default     = "terraformvm"
-}
-
-variable "vmnamesuffix" {
-  description = "vmname suffix after numbered index coming from instance variable."
-  default     = ""
-}
-
-variable "vmnameliteral" {
-  description = "vmname without any suffix or Prefix, only to be used for single instances."
-  default     = ""
+  description = "The format used to name the deployed VMs."
+  type        = string
 }
 
 variable "vmtemp" {


### PR DESCRIPTION
`vmname` variable is the format, with index coming from instance number, used to name the deployed VMs (see [`format` function](https://www.terraform.io/docs/language/functions/format.html)) (e.g. `terraform-vm-%02d`).

When only one VM is requested, `vmname` is simply the name of the deployed VM.