### PR TITLE
Merge WIndows and Linux resources and outputs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,9 +54,9 @@ locals {
   template_disk_count = length(data.vsphere_virtual_machine.template.disks)
 }
 
-// Cloning a Linux VM from a given template. Note: This is the default option!!
-resource "vsphere_virtual_machine" "Linux" {
-  count      = var.is_windows_image ? 0 : var.instances
+// Cloning a Linux or Windows VM from a given template.
+resource "vsphere_virtual_machine" "vm" {
+  count      = var.instances
   depends_on = [var.vm_depends_on]
   name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
 
@@ -136,134 +136,32 @@ resource "vsphere_virtual_machine" "Linux" {
     timeout       = var.timeout
 
     customize {
-      linux_options {
-        host_name    = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
-        domain       = var.vmdomain
-        hw_clock_utc = var.hw_clock_utc
-      }
-
-      dynamic "network_interface" {
-        for_each = keys(var.network)
+      dynamic "linux_options" {
+        for_each     = var.is_windows_image ? [] : [1]
         content {
-          ipv4_address = var.network[keys(var.network)[network_interface.key]][count.index]
-          ipv4_netmask = "%{if length(var.ipv4submask) == 1}${var.ipv4submask[0]}%{else}${var.ipv4submask[network_interface.key]}%{endif}"
+          host_name    = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+          domain       = var.vmdomain
+          hw_clock_utc = var.hw_clock_utc
         }
       }
-      dns_server_list = var.vmdns
-      dns_suffix_list = var.dns_suffix_list
-      ipv4_gateway    = var.vmgateway
-    }
-  }
 
-  // Advanced options
-  hv_mode                          = var.hv_mode
-  ept_rvi_mode                     = var.ept_rvi_mode
-  nested_hv_enabled                = var.nested_hv_enabled
-  enable_logging                   = var.enable_logging
-  cpu_performance_counters_enabled = var.cpu_performance_counters_enabled
-  swap_placement_policy            = var.swap_placement_policy
-  latency_sensitivity              = var.latency_sensitivity
-
-  shutdown_wait_timeout = var.shutdown_wait_timeout
-  force_power_off       = var.force_power_off
-}
-
-resource "vsphere_virtual_machine" "Windows" {
-  count      = var.is_windows_image ? var.instances : 0
-  depends_on = [var.vm_depends_on]
-  name       = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
-
-  resource_pool_id        = data.vsphere_resource_pool.pool.id
-  folder                  = var.vmfolder
-  tags                    = var.tag_ids != null ? var.tag_ids : data.vsphere_tag.tag[*].id
-  custom_attributes       = var.custom_attributes
-  annotation              = var.annotation
-  extra_config            = var.extra_config
-  firmware                = var.firmware
-  efi_secure_boot_enabled = var.efi_secure_boot
-  enable_disk_uuid        = var.enable_disk_uuid
-
-  datastore_cluster_id = var.datastore_cluster != "" ? data.vsphere_datastore_cluster.datastore_cluster[0].id : null
-  datastore_id         = var.datastore != "" ? data.vsphere_datastore.datastore[0].id : null
-
-  num_cpus               = var.cpu_number
-  num_cores_per_socket   = var.num_cores_per_socket
-  cpu_hot_add_enabled    = var.cpu_hot_add_enabled
-  cpu_hot_remove_enabled = var.cpu_hot_remove_enabled
-  cpu_reservation        = var.cpu_reservation
-  memory_reservation     = var.memory_reservation
-  memory                 = var.ram_size
-  memory_hot_add_enabled = var.memory_hot_add_enabled
-  guest_id               = data.vsphere_virtual_machine.template.guest_id
-  scsi_bus_sharing       = var.scsi_bus_sharing
-  scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
-  scsi_controller_count = max(max(0, flatten([
-    for item in values(var.data_disk) : [
-      for elem, val in item :
-      elem == "data_disk_scsi_controller" ? val : 0
-    ]
-  ])...) + 1, var.scsi_controller)
-  wait_for_guest_net_routable = var.wait_for_guest_net_routable
-  wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
-  wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
-
-  ignored_guest_ips = var.ignored_guest_ips
-
-  dynamic "network_interface" {
-    for_each = keys(var.network)
-    content {
-      network_id   = data.vsphere_network.network[network_interface.key].id
-      adapter_type = var.network_type != null ? var.network_type[network_interface.key] : data.vsphere_virtual_machine.template.network_interface_types[0]
-    }
-  }
-
-  // Disks defined in the original template
-  dynamic "disk" {
-    for_each = data.vsphere_virtual_machine.template.disks
-    iterator = template_disks
-    content {
-      label            = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size             = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
-      unit_number      = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
-      thin_provisioned = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
-      eagerly_scrub    = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
-      datastore_id     = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
-    }
-  }
-
-  // Additional disks defined by Terraform config
-  dynamic "disk" {
-    for_each = var.data_disk
-    iterator = terraform_disks
-    content {
-      label            = terraform_disks.key
-      size             = lookup(terraform_disks.value, "size_gb", null)
-      unit_number      = lookup(terraform_disks.value, "data_disk_scsi_controller", 0) ? terraform_disks.value.data_disk_scsi_controller * 15 + index(keys(var.data_disk), terraform_disks.key) + (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0) : index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
-      thin_provisioned = lookup(terraform_disks.value, "thin_provisioned", "true")
-      eagerly_scrub    = lookup(terraform_disks.value, "eagerly_scrub", "false")
-      datastore_id     = lookup(terraform_disks.value, "datastore_id", null)
-    }
-  }
-  clone {
-    template_uuid = data.vsphere_virtual_machine.template.id
-    linked_clone  = var.linked_clone
-    timeout       = var.timeout
-
-    customize {
-      windows_options {
-        computer_name         = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
-        admin_password        = var.local_adminpass
-        workgroup             = var.workgroup
-        join_domain           = var.windomain
-        domain_admin_user     = var.domain_admin_user
-        domain_admin_password = var.domain_admin_password
-        organization_name     = var.orgname
-        run_once_command_list = var.run_once
-        auto_logon            = var.auto_logon
-        auto_logon_count      = var.auto_logon_count
-        time_zone             = var.time_zone
-        product_key           = var.productkey
-        full_name             = var.full_name
+      dynamic "windows_options" {
+        for_each              = var.is_windows_image ? [1] : []
+        content {
+          computer_name         = "%{if var.vmnameliteral != ""}${var.vmnameliteral}%{else}${var.vmname}${count.index + 1}${var.vmnamesuffix}%{endif}"
+          admin_password        = var.local_adminpass
+          workgroup             = var.workgroup
+          join_domain           = var.windomain
+          domain_admin_user     = var.domain_admin_user
+          domain_admin_password = var.domain_admin_password
+          organization_name     = var.orgname
+          run_once_command_list = var.run_once
+          auto_logon            = var.auto_logon
+          auto_logon_count      = var.auto_logon_count
+          time_zone             = var.time_zone
+          product_key           = var.productkey
+          full_name             = var.full_name
+        }
       }
 
       dynamic "network_interface" {

--- a/output.tf
+++ b/output.tf
@@ -8,42 +8,22 @@ output "ResPool_ID" {
   value       = data.vsphere_resource_pool.pool.id
 }
 
-output "Windows-VM" {
+output "VM" {
   description = "VM Names"
-  value       = vsphere_virtual_machine.Windows.*.name
+  value       = vsphere_virtual_machine.vm.*.name
 }
 
-output "Windows-ip" {
+output "ip" {
   description = "default ip address of the deployed VM"
-  value       = vsphere_virtual_machine.Windows.*.default_ip_address
+  value       = vsphere_virtual_machine.vm.*.default_ip_address
 }
 
-output "Windows-guest-ip" {
+output "guest-ip" {
   description = "all the registered ip address of the VM"
-  value       = vsphere_virtual_machine.Windows.*.guest_ip_addresses
+  value       = vsphere_virtual_machine.vm.*.guest_ip_addresses
 }
 
-output "Windows-uuid" {
+output "uuid" {
   description = "UUID of the VM in vSphere"
-  value       = vsphere_virtual_machine.Windows.*.uuid
-}
-
-output "Linux-VM" {
-  description = "VM Names"
-  value       = vsphere_virtual_machine.Linux.*.name
-}
-
-output "Linux-ip" {
-  description = "default ip address of the deployed VM"
-  value       = vsphere_virtual_machine.Linux.*.default_ip_address
-}
-
-output "Linux-guest-ip" {
-  description = "all the registered ip address of the VM"
-  value       = vsphere_virtual_machine.Linux.*.guest_ip_addresses
-}
-
-output "Linux-uuid" {
-  description = "UUID of the VM in vSphere"
-  value       = vsphere_virtual_machine.Linux.*.uuid
+  value       = vsphere_virtual_machine.vm.*.uuid
 }


### PR DESCRIPTION
I suggest merging the two resources and outputs to get the same output names when creating Linux and Windows VMs.

The maintenance will be easier with DRY.

See plan outputs with one VM of each flavor.
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vsphere_tag.tag will be created
  + resource "vsphere_tag" "tag" {
      + category_id = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # vsphere_tag_category.category will be created
  + resource "vsphere_tag_category" "category" {
      + associable_types = [
          + "Datastore",
          + "VirtualMachine",
        ]
      + cardinality      = "SINGLE"
      + description      = "Managed by Terraform"
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["linux"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "ses"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-linux-test1"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421dc042-33dd-432e-0eca-6bf17b091b41"
          + timeout       = 30

          + customize {
              + timeout = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "terraform-linux-test1"
                  + hw_clock_utc = true
                }

              + network_interface {
                  + ipv4_netmask = 24
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 19
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk.1"
          + path              = (known after apply)
          + size              = 204800
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-7081"
        }
    }

  # module.example-server-basic["windows"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "ses"
      + force_power_off                         = true
      + guest_id                                = "windows9Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-windows-test1"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "lsilogic-sas"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421d8325-2d8e-38a6-b0ae-11b880f2ae13"
          + timeout       = 30

          + customize {
              + timeout = 10

              + network_interface {
                  + ipv4_netmask = 24
                }

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "terraform-windows-test1"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 80
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk.1"
          + path              = (known after apply)
          + size              = 204800
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "e1000e"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-7081"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```