### PR TITLE
Unit number support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,12 +86,12 @@ resource "vsphere_virtual_machine" "vm" {
   scsi_bus_sharing       = var.scsi_bus_sharing
   scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
   scsi_controller_count = max(
-    max(flatten([
+    max(0,flatten([
       for item in values(var.data_disk) : [
         for elem, val in item :
         elem == "data_disk_scsi_controller" ? val : 0
       ]])...) + 1,
-    ceil((max(flatten([
+    ceil((max(0,flatten([
       for item in values(var.data_disk) : [
         for elem, val in item :
         elem == "unit_number" ? val : 0

--- a/main.tf
+++ b/main.tf
@@ -85,12 +85,18 @@ resource "vsphere_virtual_machine" "vm" {
   guest_id               = data.vsphere_virtual_machine.template.guest_id
   scsi_bus_sharing       = var.scsi_bus_sharing
   scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
-  scsi_controller_count = max(max(0, flatten([
-    for item in values(var.data_disk) : [
-      for elem, val in item :
-      elem == "data_disk_scsi_controller" ? val : 0
-    ]
-  ])...) + 1, var.scsi_controller)
+  scsi_controller_count = max(
+    max(flatten([
+      for item in values(var.data_disk) : [
+        for elem, val in item :
+        elem == "data_disk_scsi_controller" ? val : 0
+      ]])...) + 1,
+    ceil((max(flatten([
+      for item in values(var.data_disk) : [
+        for elem, val in item :
+        elem == "unit_number" ? val : 0
+      ]  ])...) + 1) / 15),
+    var.scsi_controller)
   wait_for_guest_net_routable = var.wait_for_guest_net_routable
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
   wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
@@ -125,7 +131,27 @@ resource "vsphere_virtual_machine" "vm" {
     content {
       label             = terraform_disks.key
       size              = lookup(terraform_disks.value, "size_gb", null)
-      unit_number       = lookup(terraform_disks.value, "data_disk_scsi_controller", 0) > 0 ? terraform_disks.value.data_disk_scsi_controller * 15 + index(keys(var.data_disk), terraform_disks.key) + (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0) : index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
+      unit_number = (
+        lookup(
+          terraform_disks.value, 
+          "unit_number", 
+          -1
+        ) < 0 ? (
+          lookup(
+            terraform_disks.value, 
+            "data_disk_scsi_controller", 
+            0
+          ) > 0 ? (
+            (terraform_disks.value.data_disk_scsi_controller * 15) +
+            index(keys(var.data_disk), terraform_disks.key) + 
+            (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0)
+          ) : (
+            index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
+          )
+        ) : (
+          tonumber(terraform_disks.value["unit_number"])
+        )
+      )
       thin_provisioned  = lookup(terraform_disks.value, "thin_provisioned", "true")
       eagerly_scrub     = lookup(terraform_disks.value, "eagerly_scrub", "false")
       datastore_id      = lookup(terraform_disks.value, "datastore_id", null)

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "vsphere_virtual_machine" "vm" {
     content {
       label             = terraform_disks.key
       size              = lookup(terraform_disks.value, "size_gb", null)
-      unit_number       = lookup(terraform_disks.value, "data_disk_scsi_controller", 0) ? terraform_disks.value.data_disk_scsi_controller * 15 + index(keys(var.data_disk), terraform_disks.key) + (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0) : index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
+      unit_number       = lookup(terraform_disks.value, "data_disk_scsi_controller", 0) > 0 ? terraform_disks.value.data_disk_scsi_controller * 15 + index(keys(var.data_disk), terraform_disks.key) + (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0) : index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
       thin_provisioned  = lookup(terraform_disks.value, "thin_provisioned", "true")
       eagerly_scrub     = lookup(terraform_disks.value, "eagerly_scrub", "false")
       datastore_id      = lookup(terraform_disks.value, "datastore_id", null)

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -39,6 +39,12 @@ vm = {
         data_disk_scsi_controller = 1,
         datastore_id              = "datastore-90679"
       }
+      disk4 = {
+        size_gb                   = 5,
+        thin_provisioned          = true,
+        unit_number               = 30,
+        datastore_id              = "datastore-90679"
+      }
     }
     network = {
       "VM Port Group" = ["10.13.13.2", ""], # To use DHCP create Empty list for each instance

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -50,6 +50,8 @@ vm = {
       "VM Port Group" = ["10.13.13.2", ""], # To use DHCP create Empty list for each instance
       "VM Port Group" = ["", ""]
     }
+    tags = {}
+    annotation = null
   },
   windowsvm = {
     vmname           = "example-server-windows",
@@ -68,6 +70,7 @@ vm = {
       "VM Port Group" = ["", ""]
     }
   }
+    tags = {}
 }
 ```
 

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -71,6 +71,7 @@ vm = {
     }
   }
     tags = {}
+    annotation = null
 }
 ```
 

--- a/tests/sanity/main.tf
+++ b/tests/sanity/main.tf
@@ -19,14 +19,6 @@ variable "env" {
   default = "dev"
 }
 
-data "vsphere_storage_policy" "this" {
-  name = "Test"
-}
-
-output "disk_id" {
-  value = data.vsphere_storage_policy.this.id
-}
-
 variable "vm" {
   type = map(object({
     vmname           = string
@@ -46,22 +38,21 @@ variable "vm" {
 }
 
 module "example-server-basic" {
-  source                     = "../../"
-  for_each                   = var.vm
-  vmnameformat               = "%03d${var.env}"
-  template_storage_policy_id = [data.vsphere_storage_policy.this.id]
-  tag_depends_on             = [vsphere_tag.tag.id]
-  tags                       = each.value.tags
-  vmtemp                     = each.value.vmtemp
-  is_windows_image           = each.value.is_windows_image
-  instances                  = each.value.instances
-  vmname                     = each.value.vmname
-  vmrp                       = each.value.vmrp
-  vmfolder                   = each.value.vmfolder
-  network                    = each.value.network
-  vmgateway                  = each.value.vmgateway
-  dc                         = each.value.dc
-  datastore                  = each.value.datastore
-  data_disk                  = each.value.data_disk
+  source           = "../../"
+  for_each         = var.vm
+  vmnameformat     = "%03d${var.env}"
+  tag_depends_on   = [vsphere_tag.tag.id]
+  tags             = each.value.tags
+  vmtemp           = each.value.vmtemp
+  is_windows_image = each.value.is_windows_image
+  instances        = each.value.instances
+  vmname           = each.value.vmname
+  vmrp             = each.value.vmrp
+  vmfolder         = each.value.vmfolder
+  network          = each.value.network
+  vmgateway        = each.value.vmgateway
+  dc               = each.value.dc
+  datastore        = each.value.datastore
+  data_disk        = each.value.data_disk
 }
 

--- a/tests/smoke/main.tf
+++ b/tests/smoke/main.tf
@@ -12,6 +12,7 @@ variable "vm" {
     network          = map(list(string))
     vmgateway        = string
     dns_servers      = list(string)
+    data_disk        = map(map(string))
   }))
 }
 
@@ -29,4 +30,5 @@ module "example-server-basic" {
   vmgateway        = each.value.vmgateway
   dc               = each.value.dc
   datastore        = each.value.datastore #Either
+  data_disk        = each.value.data_disk
 }


### PR DESCRIPTION
Enables use of unit_number per data disk.  scsi_controller_count formula modified to determine how many controllers are required based on the highest of data_disk_scsi_controller, var.scsi_controller, OR highest of  (unit_number+1)/15 and rounded up using ceil().  so for the following unit_numbers they would equate to:

```
Unit#  SCSI-ID  formula-result
0      0:0      1
2      0:2      1
15     1:0      2
16     1:1      2
30     2:0      3
45     3:0      4
59     3:15     4
```

the sanity test's README.md reflects usage of unit_number, and both sanity test main.tf and README.md files also has changes that impacted use of the sanity test.  