### PR TITLE
Inherited firmware/enable_disk_uuid/efi_secure_boot

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,9 +66,9 @@ resource "vsphere_virtual_machine" "vm" {
   custom_attributes       = var.custom_attributes
   annotation              = var.annotation
   extra_config            = var.extra_config
-  firmware                = var.firmware
-  efi_secure_boot_enabled = var.efi_secure_boot
-  enable_disk_uuid        = var.enable_disk_uuid
+  firmware                = var.firmware == null ? data.vsphere_virtual_machine.template.firmware : var.firmware
+  efi_secure_boot_enabled = var.efi_secure_boot == null ? data.vsphere_virtual_machine.template.efi_secure_boot_enabled : var.efi_secure_boot
+  enable_disk_uuid        = var.enable_disk_uuid == null ? data.vsphere_virtual_machine.template.enable_disk_uuid : var.enable_disk_uuid
   storage_policy_id       = var.storage_policy_id
 
   datastore_cluster_id = var.datastore_cluster != "" ? data.vsphere_datastore_cluster.datastore_cluster[0].id : null

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "scsi_controller" {
 }
 
 variable "enable_disk_uuid" {
-  description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest."
+  description = "Expose the UUIDs of attached virtual disks to the virtual machine, allowing access to them in the guest. Default: Inherited from cloned template"
   type        = bool
   default     = null
 }
@@ -232,13 +232,13 @@ variable "dns_suffix_list" {
 }
 
 variable "firmware" {
-  description = "The firmware interface to use on the virtual machine. Can be one of bios or EFI."
-  default     = "bios"
+  description = "The firmware interface to use on the virtual machine. Can be one of bios or EFI. Default: Inherited from cloned template"
+  default     = null
 }
 
 variable "efi_secure_boot" {
-  description = "Enables EFI secure boot. Can be only be true when firmware is EFI."
-  default     = "false"
+  description = "Enables EFI secure boot. Can be only be true when firmware is EFI. Default: Inherited from cloned template"
+  default     = null
 }
 
 variable "num_cores_per_socket" {


### PR DESCRIPTION
Hi,

Pull Request to inherited firmware/enable_disk_uuid/efi_secure_boot from the template by default.

```
Initializing modules...

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/vsphere from the dependency lock file
- Using previously-installed hashicorp/vsphere v2.0.2

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
Success! The configuration is valid.


Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # vsphere_tag.tag will be created
  + resource "vsphere_tag" "tag" {
      + category_id = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # vsphere_tag_category.category will be created
  + resource "vsphere_tag_category" "category" {
      + associable_types = [
          + "Datastore",
          + "VirtualMachine",
        ]
      + cardinality      = "SINGLE"
      + description      = "Managed by Terraform"
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["linuxvm"].data.vsphere_tag.tag[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag" "tag"  {
      + category_id = (known after apply)
      + description = (known after apply)
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # module.example-server-basic["linuxvm"].data.vsphere_tag_category.category[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag_category" "category"  {
      + associable_types = (known after apply)
      + cardinality      = (known after apply)
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "dst"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "sanity-vm-linux-terraform-sanitytest001dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421d000a-9751-f734-5733-af2c4f719114"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.19.40.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "sanity-vm-linux-terraform-sanitytest001dev"
                  + hw_clock_utc = true
                }

              + network_interface {
                  + ipv4_address = "172.19.40.55"
                  + ipv4_netmask = 24
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 20
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-o91"
        }
    }

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "dst"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "sanity-vm-linux-terraform-sanitytest002dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421d000a-9751-f734-5733-af2c4f719114"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.19.40.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "sanity-vm-linux-terraform-sanitytest002dev"
                  + hw_clock_utc = true
                }

              + network_interface {
                  + ipv4_address = "172.19.40.56"
                  + ipv4_netmask = 24
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 20
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-o91"
        }
    }

  # module.example-server-basic["windowsvm"].data.vsphere_tag.tag[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag" "tag"  {
      + category_id = (known after apply)
      + description = (known after apply)
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # module.example-server-basic["windowsvm"].data.vsphere_tag_category.category[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag_category" "category"  {
      + associable_types = (known after apply)
      + cardinality      = (known after apply)
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = true
      + enable_disk_uuid                        = true
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "efi"
      + folder                                  = "dst"
      + force_power_off                         = true
      + guest_id                                = "windows9Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "sanity-vm-win-terraform-sanitytest001dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "lsilogic-sas"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421df1d2-536e-0799-2b9f-e2ee61482253"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.19.40.1"
              + timeout      = 10

              + network_interface {
                  + ipv4_address = "172.19.40.57"
                  + ipv4_netmask = 24
                }

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "sanity-vm-win-terraform-sanitytest001dev"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 100
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "e1000e"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-o91"
        }
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = true
      + enable_disk_uuid                        = true
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "efi"
      + folder                                  = "dst"
      + force_power_off                         = true
      + guest_id                                = "windows9Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "sanity-vm-win-terraform-sanitytest002dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "lsilogic-sas"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421df1d2-536e-0799-2b9f-e2ee61482253"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.19.40.1"
              + timeout      = 10

              + network_interface {
                  + ipv4_address = "172.19.40.58"
                  + ipv4_netmask = 24
                }

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "sanity-vm-win-terraform-sanitytest002dev"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 100
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "e1000e"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-o91"
        }
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + DC_ID = {
      + "linuxvm"   = "datacenter-21"
      + "windowsvm" = "datacenter-21"
    }
  + VM    = {
      + "linuxvm"   = [
          + "sanity-vm-linux-terraform-sanitytest001dev",
          + "sanity-vm-linux-terraform-sanitytest002dev",
        ]
      + "windowsvm" = [
          + "sanity-vm-win-terraform-sanitytest001dev",
          + "sanity-vm-win-terraform-sanitytest002dev",
        ]
    }

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vsphere_tag_category.category: Creating...
vsphere_tag_category.category: Creation complete after 0s [id=urn:vmomi:InventoryServiceCategory:39269528-9248-455e-9feb-67b10fbcc486:GLOBAL]
vsphere_tag.tag: Creating...
vsphere_tag.tag: Creation complete after 0s [id=urn:vmomi:InventoryServiceTag:ca22deb0-13aa-4f0e-b3b3-010816e23f2a:GLOBAL]
module.example-server-basic["windowsvm"].data.vsphere_tag_category.category[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_tag_category.category[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_tag_category.category[0]: Read complete after 0s [id=urn:vmomi:InventoryServiceCategory:39269528-9248-455e-9feb-67b10fbcc486:GLOBAL]
module.example-server-basic["linuxvm"].data.vsphere_tag.tag[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_tag_category.category[0]: Read complete after 0s [id=urn:vmomi:InventoryServiceCategory:39269528-9248-455e-9feb-67b10fbcc486:GLOBAL]
module.example-server-basic["windowsvm"].data.vsphere_tag.tag[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_tag.tag[0]: Read complete after 0s [id=urn:vmomi:InventoryServiceTag:ca22deb0-13aa-4f0e-b3b3-010816e23f2a:GLOBAL]
module.example-server-basic["windowsvm"].data.vsphere_tag.tag[0]: Read complete after 0s [id=urn:vmomi:InventoryServiceTag:ca22deb0-13aa-4f0e-b3b3-010816e23f2a:GLOBAL]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Creating...
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Creating...
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Creating...
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Creating...
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [10s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [10s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [20s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [20s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [30s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [30s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [40s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [40s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [50s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [50s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m0s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m0s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m10s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m10s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1]: Creation complete after 1m19s [id=421d02d8-138c-63bb-292a-8a2314ab52cc]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m20s elapsed]
module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0]: Creation complete after 1m27s [id=421d9f42-238e-1eea-c50b-f3cf39cf74ef]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [1m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [1m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [2m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [2m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [3m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [3m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [4m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [4m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [5m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m0s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [5m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m10s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [5m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m20s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Still creating... [5m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m30s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1]: Creation complete after 5m39s [id=421de8d6-16d6-9d7a-9ad4-3d477a8c4100]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m40s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Still creating... [5m50s elapsed]
module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0]: Creation complete after 5m50s [id=421d3379-1c63-f5a3-5d7e-9703b58d0762]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

DC_ID = tomap({
  "linuxvm" = "datacenter-21"
  "windowsvm" = "datacenter-21"
})
VM = tomap({
  "linuxvm" = [
    "sanity-vm-linux-terraform-sanitytest001dev",
    "sanity-vm-linux-terraform-sanitytest002dev",
  ]
  "windowsvm" = [
    "sanity-vm-win-terraform-sanitytest001dev",
    "sanity-vm-win-terraform-sanitytest002dev",
  ]
})
```
