### PR TITLE
CIDR support, removed ipv4_netmask if dhcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ module "example-server-linuxvm" {
   vmname    = "example-server-linux"
   vmrp      = "esxi/Resources - or name of a resource pool"
   network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
+    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]; You can also use a CIDR annotation;
   }
   vmgateway = "10.13.113.1"
   dc        = "Datacenter"
@@ -94,7 +94,7 @@ module "example-server-windowsvm-advanced" {
   vmnameformat      = "%03d" #To use three decimal with leading zero vmnames will be AdvancedVM001,AdvancedVM002
   domain            = "somedomain.com"
   network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
+    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]; You can also use a CIDR annotation;
     "Second Network Card"               = ["", ""]
   }
   ipv4submask  = ["24", "8"]

--- a/main.tf
+++ b/main.tf
@@ -205,8 +205,14 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "network_interface" {
         for_each = keys(var.network)
         content {
-          ipv4_address = var.network[keys(var.network)[network_interface.key]][count.index]
-          ipv4_netmask = "%{if length(var.ipv4submask) == 1}${var.ipv4submask[0]}%{else}${var.ipv4submask[network_interface.key]}%{endif}"
+          ipv4_address = split("/", var.network[keys(var.network)[network_interface.key]][count.index])[0]
+          ipv4_netmask = var.network[keys(var.network)[network_interface.key]][count.index] == "" ? null : (
+                           length(split("/", var.network[keys(var.network)[network_interface.key]][count.index])) == 2 ? (
+                             split("/", var.network[keys(var.network)[network_interface.key]][count.index])[1]
+                           ) : (
+                             length(var.ipv4submask) == 1 ? var.ipv4submask[0] : var.ipv4submask[network_interface.key]
+                           )
+                         )
         }
       }
       dns_server_list = var.dns_server_list

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 #Network Section
 variable "network" {
-  description = "Define PortGroup and IPs for each VM"
+  description = "Define PortGroup and IPs/CIDR for each VM. If no CIDR provided, the subnet mask is taken from var.ipv4submask."
   type        = map(list(string))
   default     = {}
 }
@@ -12,7 +12,7 @@ variable "network_type" {
 }
 
 variable "ipv4submask" {
-  description = "ipv4 Subnet mask."
+  description = "ipv4 Subnet mask. Warning: The order must follow the alphabetic order from var.network."
   type        = list(any)
   default     = ["24"]
 }


### PR DESCRIPTION
Hi,

Pull Request to :

-  support CIDR annotation for the network variable.

If not a CIDR, fallback to previous behavior.
The CIDR annotation motivation is to avoid the usage of the ipv4submask.
Terraform map are sorted in an alphabetical order which can be quite confusing with the order of the ipv4submask list.
The following example : 

```
network = {
    "b_network" = [ "1.1.1.1"]
    "a_network" = ["2.2.2.2"]
}
ipv4submask = ["/24", "/22"]
```

will produce : 

```
              + network_interface {
                  + ipv4_address = "2.2.2.2"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "1.1.1.1"
                  + ipv4_netmask = 22
                }
```
which is confusing. Most the users will expected to have the /24 apply to b_network.

- removed unused attribute ipv4_netmask of the network_interface if dhcp is used. It's already working as the attribute is not taken in consideration but do not make sense to have it defined.



**Tests :** 

spec:
```
  instances     = 2
  network = {
    "t1-ext-pks-mgt" = ["172.19.40.55", "172.19.40.56"]
    "vm_network" = ["172.19.40.57", "172.19.40.58"]
  }
  ipv4submask = ["24", "22"]
```
result:
```
vm[0]
              + network_interface {
                  + ipv4_address = "172.19.40.55"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.57"
                  + ipv4_netmask = 22
                }


vm[1]
              + network_interface {
                  + ipv4_address = "172.19.40.56"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.58"
                  + ipv4_netmask = 22
                }
```

spec:
```
instances     = 2
  network = {
    "t1-ext-pks-mgt" = ["172.19.40.55", "172.19.40.56"]
    "vm_network" = ["172.19.40.57", "172.19.40.58"]
  }
```
result:
```
vm[0]
              + network_interface {
                  + ipv4_address = "172.19.40.55"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.57"
                  + ipv4_netmask = 24
                }


vm[1]
              + network_interface {
                  + ipv4_address = "172.19.40.56"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.58"
                  + ipv4_netmask = 24
                }
```
spec:
```
  instances     = 2
  network = {
    "t1-ext-pks-mgt" = ["172.19.40.55/24", "172.19.40.56/24"]
    "vm_network" = ["172.19.40.57/22", "172.19.40.58/22"]
  }
```

result:
```
vm[0]
              + network_interface {
                  + ipv4_address = "172.19.40.55"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.57"
                  + ipv4_netmask = 22
                }
vm[1]
              + network_interface {
                  + ipv4_address = "172.19.40.56"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.58"
                  + ipv4_netmask = 22
                }
```

spec:
```
  instances     = 2
  network = {
    "t1-ext-pks-mgt" = ["172.19.40.55", "172.19.40.56/24"]
    "vm_network" = ["172.19.40.57", "172.19.40.58/22"]
  }
  ipv4submask = ["24", "22"]
```
result
```
vm[0]
              + network_interface {
                  + ipv4_address = "172.19.40.55"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.57"
                  + ipv4_netmask = 22
                }
vm[1]
              + network_interface {
                  + ipv4_address = "172.19.40.56"
                  + ipv4_netmask = 24
                }
              + network_interface {
                  + ipv4_address = "172.19.40.58"
                  + ipv4_netmask = 22
                }
```
spec:
```
  instances     = 2
  network = {
    "vm_network" = ["1.1.1.1", ""]
  }
  ipv4submask = ["22"]
```
result:
```
vm[0]
              + network_interface {
                  + ipv4_address = "1.1.1.1"
                  + ipv4_netmask = 22
                }
vm[1]
		+ network_interface {}
```
