### PR TITLE
added VM disk output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -27,3 +27,8 @@ output "uuid" {
   description = "UUID of the VM in vSphere"
   value       = vsphere_virtual_machine.vm.*.uuid
 }
+
+output "disk" {
+  description = "Disks of the deployed VM"
+  value       = vsphere_virtual_machine.vm.*.disk
+}


### PR DESCRIPTION
Hi,

Pull Request to expose disk information to the module output.
This allow to trigger external null_resource to the disk.

example with an automatic resize:

```
resource "null_resource" "storage" {
  count = var.instances
  triggers = {
    disks = join(",", flatten([module.vm.disk[count.index][*].size]))
  }
  provisioner "remote-exec" { # automatic resize }
  [...]
```

sanity outputs:

```
Changes to Outputs:
  + DC_ID = {
      + "linuxvm"   = "datacenter-21"
      + "windowsvm" = "datacenter-21"
    }
  + VM    = {
      + "linuxvm"   = [
          + "sanity-vm-linux-terraform-sanitytest001dev",
          + "sanity-vm-linux-terraform-sanitytest002dev",
        ]
      + "windowsvm" = [
          + "sanity-vm-win-terraform-sanitytest001dev",
          + "sanity-vm-win-terraform-sanitytest002dev",
        ]
    }
  + disk  = {
      + "linuxvm"   = [
          + [
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk0"
                  + path              = (known after apply)
                  + size              = 20
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 0
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 0
                  + io_share_count    = 0
                  + io_share_level    = "normal"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk1"
                  + path              = (known after apply)
                  + size              = 30
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = false
                  + unit_number       = 1
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk2"
                  + path              = (known after apply)
                  + size              = 70
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 16
                  + uuid              = (known after apply)
                  + write_through     = false
                },
            ],
          + [
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk0"
                  + path              = (known after apply)
                  + size              = 20
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 0
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 0
                  + io_share_count    = 0
                  + io_share_level    = "normal"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk1"
                  + path              = (known after apply)
                  + size              = 30
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = false
                  + unit_number       = 1
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk2"
                  + path              = (known after apply)
                  + size              = 70
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 16
                  + uuid              = (known after apply)
                  + write_through     = false
                },
            ],
        ]
      + "windowsvm" = [
          + [
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk0"
                  + path              = (known after apply)
                  + size              = 100
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 0
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 0
                  + io_share_count    = 0
                  + io_share_level    = "normal"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk1"
                  + path              = (known after apply)
                  + size              = 30
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = false
                  + unit_number       = 1
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk2"
                  + path              = (known after apply)
                  + size              = 70
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 16
                  + uuid              = (known after apply)
                  + write_through     = false
                },
            ],
          + [
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk0"
                  + path              = (known after apply)
                  + size              = 100
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 0
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 0
                  + io_share_count    = 0
                  + io_share_level    = "normal"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk1"
                  + path              = (known after apply)
                  + size              = 30
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = false
                  + unit_number       = 1
                  + uuid              = (known after apply)
                  + write_through     = false
                },
              + {
                  + attach            = false
                  + controller_type   = "scsi"
                  + datastore_id      = "<computed>"
                  + device_address    = (known after apply)
                  + disk_mode         = "persistent"
                  + disk_sharing      = "sharingNone"
                  + eagerly_scrub     = false
                  + io_limit          = -1
                  + io_reservation    = 15
                  + io_share_count    = 2000
                  + io_share_level    = "custom"
                  + keep_on_remove    = false
                  + key               = 0
                  + label             = "disk2"
                  + path              = (known after apply)
                  + size              = 70
                  + storage_policy_id = (known after apply)
                  + thin_provisioned  = true
                  + unit_number       = 16
                  + uuid              = (known after apply)
                  + write_through     = false
                },
            ],
        ]
    }
```
