### PR TITLE
Added disk_mode support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,7 @@ resource "vsphere_virtual_machine" "vm" {
       io_reservation    = length(var.io_reservation) > 0 ? var.io_reservation[template_disks.key] : null
       io_share_level    = length(var.io_share_level) > 0 ? var.io_share_level[template_disks.key] : "normal"
       io_share_count    = length(var.io_share_level) > 0 && var.io_share_level[template_disks.key] == "custom" ? var.io_share_count[template_disks.key] : null
+      disk_mode         = length(var.disk_mode) > 0 ? var.disk_mode[template_disks.key] : null
     }
   }
   // Additional disks defined by Terraform config
@@ -171,6 +172,7 @@ resource "vsphere_virtual_machine" "vm" {
       io_reservation    = lookup(terraform_disks.value, "io_reservation", null)
       io_share_level    = lookup(terraform_disks.value, "io_share_level", "normal")
       io_share_count    = lookup(terraform_disks.value, "io_share_level", null) == "custom" ? lookup(terraform_disks.value, "io_share_count") : null
+      disk_mode         = lookup(terraform_disks.value, "disk_mode", null)
     }
   }
   clone {

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,12 @@ variable "io_share_count" {
   default     = []
 }
 
+variable "disk_mode" {
+  description = "The disk mode for the disk."
+  type        = list(string)
+  default     = []
+}
+
 variable "template_storage_policy_id" {
   description = "List of UUIDs of the storage policy to assign to the template disk."
   type        = list(any)


### PR DESCRIPTION
Hi
Please merge this PR.  Below is the sanity test output

```
Terraform will perform the following actions:

  # vsphere_tag.tag will be created
  + resource "vsphere_tag" "tag" {
      + category_id = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # vsphere_tag_category.category will be created
  + resource "vsphere_tag_category" "category" {
      + associable_types = [
          + "Datastore",
          + "VirtualMachine",
        ]
      + cardinality      = "SINGLE"
      + description      = "Managed by Terraform"
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["linuxvm"].data.vsphere_tag.tag[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag" "tag"  {
      + category_id = (known after apply)
      + description = (known after apply)
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # module.example-server-basic["linuxvm"].data.vsphere_tag_category.category[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag_category" "category"  {
      + associable_types = (known after apply)
      + cardinality      = (known after apply)
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-35629"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "PawelT_Test"
      + force_power_off                         = true
      + guest_id                                = "rhel7_64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest001dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-35573"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42322eca-5703-71d5-a8a3-873cd838f4f7"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "10.13.13.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "terraform-sanitytest001dev"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 6
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-16"
        }
    }

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-35629"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "PawelT_Test"
      + force_power_off                         = true
      + guest_id                                = "rhel7_64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest002dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-35573"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42322eca-5703-71d5-a8a3-873cd838f4f7"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "10.13.13.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "terraform-sanitytest002dev"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 6
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-16"
        }
    }

  # module.example-server-basic["windowsvm"].data.vsphere_tag.tag[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag" "tag"  {
      + category_id = (known after apply)
      + description = (known after apply)
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # module.example-server-basic["windowsvm"].data.vsphere_tag_category.category[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag_category" "category"  {
      + associable_types = (known after apply)
      + cardinality      = (known after apply)
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-35629"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = true
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "PawelT_Test"
      + force_power_off                         = true
      + guest_id                                = "windows8Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest001dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-35573"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42322eb1-d729-6667-c89c-81842a43a0ad"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "10.13.13.1"
              + timeout      = 10

              + network_interface {}

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "terraform-sanitytest001dev"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 63
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-16"
        }
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-35629"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = true
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "PawelT_Test"
      + force_power_off                         = true
      + guest_id                                = "windows8Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest002dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-35573"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42322eb1-d729-6667-c89c-81842a43a0ad"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "10.13.13.1"
              + timeout      = 10

              + network_interface {}

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "terraform-sanitytest002dev"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 63
          + storage_policy_id = (known after apply)
          + thin_provisioned  = false
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-16"
        }
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + DC_ID = {
      + "linuxvm"   = "datacenter-2"
      + "windowsvm" = "datacenter-2"
    }
  + VM    = {
      + "linuxvm"   = [
          + "terraform-sanitytest001dev",
          + "terraform-sanitytest002dev",
        ]
      + "windowsvm" = [
          + "terraform-sanitytest001dev",
          + "terraform-sanitytest002dev",
        ]
    }

```