### PR TITLE
update: VM FQDN Name Support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,7 @@ resource "vsphere_virtual_machine" "vm" {
     timeout       = var.timeout
 
     customize {
+      timeout = var.wait_for_guest_customization_timeout
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   count      = var.instances
   depends_on = [var.vm_depends_on]
-  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+  name       = "${var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)}${var.fqdnvmname == true ? ".${var.domain}" : ""}"
 
   resource_pool_id        = data.vsphere_resource_pool.pool.id
   folder                  = var.vmfolder

--- a/variables.tf
+++ b/variables.tf
@@ -388,6 +388,12 @@ variable "wait_for_guest_net_timeout" {
   default     = 5
 }
 
+variable "wait_for_guest_customization_timeout" {
+  description = "(Optional) The time, in minutes that Terraform waits for customization to complete before failing. The default is 10 minutes, and setting the value to 0 or a negative value disables the waiter altogether."
+  type        =  number
+  default     =  10
+}
+
 variable "ignored_guest_ips" {
   description = "List of IP addresses and CIDR networks to ignore while waiting for an available IP address using either of the waiters. Any IP addresses in this list will be ignored if they show up so that the waiter will continue to wait for a real IP address."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,12 @@ variable "staticvmname" {
   default     = null
 }
 
+variable "fqdnvmname" {
+  description = "If true, the vm will be created using domain variable appended"
+  type        = bool
+  default     = false
+}
+
 variable "vmtemp" {
   description = "Name of the template available in the vSphere."
 }
@@ -290,7 +296,7 @@ variable "hw_clock_utc" {
 }
 
 variable "domain" {
-  description = "default VM domain for linux guest customization."
+  description = "default VM domain for linux guest customization and fqdn name (if fqdnvmname is true)."
   default     = "Development.com"
 }
 


### PR DESCRIPTION
This Pull request is for this issue here: <https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/issues/95#event-5076737086>

User [damnsam](https://github.com/damnsam) did not Open a Pull Request so this issue was closed without solution. But his solution was considered as good.

So i replicated his damnsams Solution and tested it in my environment. It works for me.
When "fqdnvmname" is set to true then vm Name and Domain are use for VM-Name. So the virtual Machine reads as FQDN

Can you merge this in the main project?