### PR TITLE
Support template from Content Library

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,23 @@ resource "vsphere_virtual_machine" "vm" {
       io_share_count    = length(var.io_share_level) > 0 && var.io_share_level[template_disks.key] == "custom" ? var.io_share_count[template_disks.key] : null
     }
   }
+  // Disk for template from Content Library
+  dynamic "disk" {
+    for_each = var.content_library == null ? [] : [1]
+    iterator = template_disks
+    content {
+      label             = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
+      size              = var.disk_size_gb[template_disks.key]
+      unit_number       = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
+      // thin_provisioned  = data.vsphere_virtual_machine.template[0].disks[template_disks.key].thin_provisioned
+      // eagerly_scrub     = data.vsphere_virtual_machine.template[0].disks[template_disks.key].eagerly_scrub
+      datastore_id      = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
+      storage_policy_id = length(var.template_storage_policy_id) > 0 ? var.template_storage_policy_id[template_disks.key] : null
+      io_reservation    = length(var.io_reservation) > 0 ? var.io_reservation[template_disks.key] : null
+      io_share_level    = length(var.io_share_level) > 0 ? var.io_share_level[template_disks.key] : "normal"
+      io_share_count    = length(var.io_share_level) > 0 && var.io_share_level[template_disks.key] == "custom" ? var.io_share_count[template_disks.key] : null
+    }
+  }
   // Additional disks defined by Terraform config
   dynamic "disk" {
     for_each = var.data_disk

--- a/main.tf
+++ b/main.tf
@@ -50,8 +50,8 @@ data "vsphere_tag" "tag" {
 }
 
 data "vsphere_folder" "folder" {
-  count       = var.vmfolder != null ? 1 : 0
-  path        = "/${data.vsphere_datacenter.dc.name}/vm/${var.vmfolder}"
+  count = var.vmfolder != null ? 1 : 0
+  path  = "/${data.vsphere_datacenter.dc.name}/vm/${var.vmfolder}"
 }
 
 locals {
@@ -95,17 +95,17 @@ resource "vsphere_virtual_machine" "vm" {
   scsi_bus_sharing       = var.scsi_bus_sharing
   scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
   scsi_controller_count = max(
-    max(0,flatten([
+    max(0, flatten([
       for item in values(var.data_disk) : [
         for elem, val in item :
         elem == "data_disk_scsi_controller" ? val : 0
-      ]])...) + 1,
-    ceil((max(0,flatten([
+    ]])...) + 1,
+    ceil((max(0, flatten([
       for item in values(var.data_disk) : [
         for elem, val in item :
         elem == "unit_number" ? val : 0
-      ]  ])...) + 1) / 15),
-    var.scsi_controller)
+    ]])...) + 1) / 15),
+  var.scsi_controller)
   wait_for_guest_net_routable = var.wait_for_guest_net_routable
   wait_for_guest_ip_timeout   = var.wait_for_guest_ip_timeout
   wait_for_guest_net_timeout  = var.wait_for_guest_net_timeout
@@ -141,26 +141,26 @@ resource "vsphere_virtual_machine" "vm" {
     for_each = var.data_disk
     iterator = terraform_disks
     content {
-      label             = terraform_disks.key
-      size              = lookup(terraform_disks.value, "size_gb", null)
+      label = terraform_disks.key
+      size  = lookup(terraform_disks.value, "size_gb", null)
       unit_number = (
         lookup(
-          terraform_disks.value, 
-          "unit_number", 
+          terraform_disks.value,
+          "unit_number",
           -1
-        ) < 0 ? (
+          ) < 0 ? (
           lookup(
-            terraform_disks.value, 
-            "data_disk_scsi_controller", 
+            terraform_disks.value,
+            "data_disk_scsi_controller",
             0
-          ) > 0 ? (
+            ) > 0 ? (
             (terraform_disks.value.data_disk_scsi_controller * 15) +
-            index(keys(var.data_disk), terraform_disks.key) + 
+            index(keys(var.data_disk), terraform_disks.key) +
             (var.scsi_controller == tonumber(terraform_disks.value["data_disk_scsi_controller"]) ? local.template_disk_count : 0)
-          ) : (
+            ) : (
             index(keys(var.data_disk), terraform_disks.key) + local.template_disk_count
           )
-        ) : (
+          ) : (
           tonumber(terraform_disks.value["unit_number"])
         )
       )
@@ -212,12 +212,12 @@ resource "vsphere_virtual_machine" "vm" {
         content {
           ipv4_address = split("/", var.network[keys(var.network)[network_interface.key]][count.index])[0]
           ipv4_netmask = var.network[keys(var.network)[network_interface.key]][count.index] == "" ? null : (
-                           length(split("/", var.network[keys(var.network)[network_interface.key]][count.index])) == 2 ? (
-                             split("/", var.network[keys(var.network)[network_interface.key]][count.index])[1]
-                           ) : (
-                             length(var.ipv4submask) == 1 ? var.ipv4submask[0] : var.ipv4submask[network_interface.key]
-                           )
-                         )
+            length(split("/", var.network[keys(var.network)[network_interface.key]][count.index])) == 2 ? (
+              split("/", var.network[keys(var.network)[network_interface.key]][count.index])[1]
+              ) : (
+              length(var.ipv4submask) == 1 ? var.ipv4submask[0] : var.ipv4submask[network_interface.key]
+            )
+          )
         }
       }
       dns_server_list = var.dns_server_list

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,23 @@ data "vsphere_network" "network" {
 }
 
 data "vsphere_virtual_machine" "template" {
+  count         = var.content_library == null ? 1 : 0
   name          = var.vmtemp
   datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_content_library" "library" {
+  count      = var.content_library != null ? 1 : 0
+  name       = var.content_library
+  depends_on = [var.tag_depends_on]
+}
+
+data "vsphere_content_library_item" "library_item_template" {
+  count      = var.content_library != null ? 1 : 0
+  library_id = data.vsphere_content_library.library[0].id
+  type       = "ovf"
+  name       = var.vmtemp
+  depends_on = [var.tag_depends_on]
 }
 
 data "vsphere_tag_category" "category" {
@@ -56,7 +71,7 @@ data "vsphere_folder" "folder" {
 
 locals {
   interface_count     = length(var.ipv4submask) #Used for Subnet handeling
-  template_disk_count = length(data.vsphere_virtual_machine.template.disks)
+  template_disk_count = var.content_library == null ? length(data.vsphere_virtual_machine.template[0].disks) : 0
 }
 
 // Cloning a Linux or Windows VM from a given template.
@@ -71,9 +86,9 @@ resource "vsphere_virtual_machine" "vm" {
   custom_attributes       = var.custom_attributes
   annotation              = var.annotation
   extra_config            = var.extra_config
-  firmware                = var.firmware == null ? data.vsphere_virtual_machine.template.firmware : var.firmware
-  efi_secure_boot_enabled = var.efi_secure_boot == null ? data.vsphere_virtual_machine.template.efi_secure_boot_enabled : var.efi_secure_boot
-  enable_disk_uuid        = var.enable_disk_uuid == null ? data.vsphere_virtual_machine.template.enable_disk_uuid : var.enable_disk_uuid
+  firmware                = var.content_library == null && var.firmware == null ? data.vsphere_virtual_machine.template[0].firmware : var.firmware
+  efi_secure_boot_enabled = var.content_library == null && var.efi_secure_boot == null ? data.vsphere_virtual_machine.template[0].efi_secure_boot_enabled : var.efi_secure_boot
+  enable_disk_uuid        = var.content_library == null && var.enable_disk_uuid == null ? data.vsphere_virtual_machine.template[0].enable_disk_uuid : var.enable_disk_uuid
   storage_policy_id       = var.storage_policy_id
 
   datastore_cluster_id = var.datastore_cluster != "" ? data.vsphere_datastore_cluster.datastore_cluster[0].id : null
@@ -91,9 +106,9 @@ resource "vsphere_virtual_machine" "vm" {
   memory_hot_add_enabled = var.memory_hot_add_enabled
   memory_share_level     = var.memory_share_level
   memory_share_count     = var.memory_share_level == "custom" ? var.memory_share_count : null
-  guest_id               = data.vsphere_virtual_machine.template.guest_id
+  guest_id               = var.content_library == null ? data.vsphere_virtual_machine.template[0].guest_id : null
   scsi_bus_sharing       = var.scsi_bus_sharing
-  scsi_type              = var.scsi_type != "" ? var.scsi_type : data.vsphere_virtual_machine.template.scsi_type
+  scsi_type              = var.scsi_type != "" ? var.scsi_type : (var.content_library == null ? data.vsphere_virtual_machine.template[0].scsi_type : null)
   scsi_controller_count = max(
     max(0, flatten([
       for item in values(var.data_disk) : [
@@ -116,19 +131,19 @@ resource "vsphere_virtual_machine" "vm" {
     for_each = keys(var.network) #data.vsphere_network.network[*].id #other option
     content {
       network_id   = data.vsphere_network.network[network_interface.key].id
-      adapter_type = var.network_type != null ? var.network_type[network_interface.key] : data.vsphere_virtual_machine.template.network_interface_types[0]
+      adapter_type = var.network_type != null ? var.network_type[network_interface.key] : (var.content_library == null ? data.vsphere_virtual_machine.template[0].network_interface_types[0] : null)
     }
   }
   // Disks defined in the original template
   dynamic "disk" {
-    for_each = data.vsphere_virtual_machine.template.disks
+    for_each = var.content_library == null ? data.vsphere_virtual_machine.template[0].disks : []
     iterator = template_disks
     content {
       label             = length(var.disk_label) > 0 ? var.disk_label[template_disks.key] : "disk${template_disks.key}"
-      size              = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template.disks[template_disks.key].size
+      size              = var.disk_size_gb != null ? var.disk_size_gb[template_disks.key] : data.vsphere_virtual_machine.template[0].disks[template_disks.key].size
       unit_number       = var.scsi_controller != null ? var.scsi_controller * 15 + template_disks.key : template_disks.key
-      thin_provisioned  = data.vsphere_virtual_machine.template.disks[template_disks.key].thin_provisioned
-      eagerly_scrub     = data.vsphere_virtual_machine.template.disks[template_disks.key].eagerly_scrub
+      thin_provisioned  = data.vsphere_virtual_machine.template[0].disks[template_disks.key].thin_provisioned
+      eagerly_scrub     = data.vsphere_virtual_machine.template[0].disks[template_disks.key].eagerly_scrub
       datastore_id      = var.disk_datastore != "" ? data.vsphere_datastore.disk_datastore[0].id : null
       storage_policy_id = length(var.template_storage_policy_id) > 0 ? var.template_storage_policy_id[template_disks.key] : null
       io_reservation    = length(var.io_reservation) > 0 ? var.io_reservation[template_disks.key] : null
@@ -174,7 +189,7 @@ resource "vsphere_virtual_machine" "vm" {
     }
   }
   clone {
-    template_uuid = data.vsphere_virtual_machine.template.id
+    template_uuid = var.content_library == null ? data.vsphere_virtual_machine.template[0].id : data.vsphere_content_library_item.library_item_template[0].id
     linked_clone  = var.linked_clone
     timeout       = var.timeout
 

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -13,6 +13,7 @@ vm = {
   linuxvm = {
     vmname            = "example-server-linux",
     vmtemp            = "fill"
+    content_library   = null
     annotation        = "Terraform Smoke Test"
     instances         = 0
     is_windows_image  = false

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -1,6 +1,6 @@
 # Smoke Test
 
-You need to run the plan using vars.tfvars 
+You need to run the plan using private.tfvars 
 
 ### Example:
 
@@ -26,6 +26,7 @@ vm = {
     network = {
       "VM Networks" = ["10.13.13.2"],
     }
+    disk_size_gb = [ 20 ]
   }
 }
 ```

--- a/tests/smoke/main.tf
+++ b/tests/smoke/main.tf
@@ -16,6 +16,7 @@ variable "vm" {
     is_windows_image = bool
     instances        = number
     network          = map(list(string))
+    disk_size_gb     = list(number)
     vmgateway        = string
     dns_servers      = list(string)
   }))
@@ -33,6 +34,7 @@ module "example-server-basic" {
   vmrp             = each.value.vmrp
   vmfolder         = each.value.vmfolder
   network          = each.value.network
+  disk_size_gb     = each.value.disk_size_gb
   vmgateway        = each.value.vmgateway
   dc               = each.value.dc
   datastore        = each.value.datastore #Either

--- a/tests/smoke/main.tf
+++ b/tests/smoke/main.tf
@@ -7,6 +7,7 @@ variable "vm" {
   type = map(object({
     vmname           = string
     vmtemp           = string
+    content_library  = string
     annotation       = string
     dc               = string
     vmrp             = string
@@ -24,6 +25,7 @@ module "example-server-basic" {
   source           = "../../"
   for_each         = var.vm
   vmtemp           = each.value.vmtemp
+  content_library  = each.value.content_library
   annotation       = each.value.annotation
   is_windows_image = each.value.is_windows_image
   instances        = each.value.instances

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,11 @@ variable "vmtemp" {
   description = "Name of the template available in the vSphere."
 }
 
+variable "content_library" {
+  description = "Name of the content library where the OVF template is stored."
+  default     = null
+}
+
 variable "instances" {
   description = "number of instances you want deploy from the template."
   default     = 1


### PR DESCRIPTION
Add support for OVF template from Content Library.

See test plan output.
```
Terraform will perform the following actions:

  # vsphere_tag.tag will be created
  + resource "vsphere_tag" "tag" {
      + category_id = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # vsphere_tag_category.category will be created
  + resource "vsphere_tag_category" "category" {
      + associable_types = [
          + "Datastore",
          + "VirtualMachine",
        ]
      + cardinality      = "SINGLE"
      + description      = "Managed by Terraform"
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["vm"].data.vsphere_tag.tag[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag" "tag"  {
      + category_id = (known after apply)
      + description = (known after apply)
      + id          = (known after apply)
      + name        = "terraform-test-tag"
    }

  # module.example-server-basic["vm"].data.vsphere_tag_category.category[0] will be read during apply
  # (config refers to values not yet known)
 <= data "vsphere_tag_category" "category"  {
      + associable_types = (known after apply)
      + cardinality      = (known after apply)
      + description      = (known after apply)
      + id               = (known after apply)
      + name             = "terraform-test-category"
    }

  # module.example-server-basic["vm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "ses"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest001dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421d4570-af05-01f1-9957-1a2fce7a9ff4"
          + timeout       = 30

          + customize {
              + timeout = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "terraform-sanitytest001dev"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 20
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-7081"
        }
    }

  # module.example-server-basic["vm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + annotation                              = "Terraform Sanity Test"
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = 2000
      + cpu_share_level                         = "custom"
      + datastore_id                            = "datastore-7086"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "ses"
      + force_power_off                         = true
      + guest_id                                = "ubuntu64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = 2000
      + memory_share_level                      = "custom"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "terraform-sanitytest002dev"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-7075"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 2
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + tags                                    = (known after apply)
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "421d4570-af05-01f1-9957-1a2fce7a9ff4"
          + timeout       = 30

          + customize {
              + timeout = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "terraform-sanitytest002dev"
                  + hw_clock_utc = true
                }

              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 20
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk1"
          + path              = (known after apply)
          + size              = 30
          + storage_policy_id = "ff45cc66-b624-4621-967f-1aef6437f568"
          + thin_provisioned  = false
          + unit_number       = 1
          + uuid              = (known after apply)
          + write_through     = false
        }
      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 15
          + io_share_count    = 2000
          + io_share_level    = "custom"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk2"
          + path              = (known after apply)
          + size              = 70
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 16
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-7081"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + DC_ID = {
      + "vm" = "datacenter-21"
    }
  + VM    = {
      + "vm" = [
          + "terraform-sanitytest001dev",
          + "terraform-sanitytest002dev",
        ]
    }
```