### PR TITLE
update: Ability to set different timeout for guest_customization

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -257,6 +257,7 @@ resource "vsphere_virtual_machine" "vm" {
       dns_server_list = var.dns_server_list
       dns_suffix_list = var.dns_suffix_list
       ipv4_gateway    = var.vmgateway
+      timeout         = var.wait_for_guest_customization_timeout
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -393,6 +393,13 @@ variable "wait_for_guest_net_timeout" {
   default     = 5
 }
 
+variable "wait_for_guest_customization_timeout" {
+  description = "(Optional) The time, in minutes that Terraform waits for customization to complete before failing. The default is 10 minutes, and setting the value to 0 or a negative value disables the waiter altogether."
+  type        =  number
+  default     =  10
+}
+
+
 variable "ignored_guest_ips" {
   description = "List of IP addresses and CIDR networks to ignore while waiting for an available IP address using either of the waiters. Any IP addresses in this list will be ignored if they show up so that the waiter will continue to wait for a real IP address."
   type        = list(string)


### PR DESCRIPTION
I had the same issue like in Issue #739
[https://github.com/hashicorp/terraform-provider-vsphere/issues/739](https://github.com/hashicorp/terraform-provider-vsphere/issues/739)

Guest Customization took too long (which can last quite long on Windows Servers) which leaded to timeout.
There was no possibility to set `wait_for_guest_customization_timeout`. So i made a fork to set it myself

In my case i set wait_for_guest_customization_timeout to 30 Minutes -> after 20 Minutes of deployment my VM was successfully created without errors

So the ability to set different `wait_for_guest_customization_timeout` seems to be necessary.

