### PR TITLE
Add required_providers for provider alias compatibility

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.13.4"
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "2.0.2"
+    }
+  }
 }


### PR DESCRIPTION
Calling the module with a providers alias defined generates a warning. 

> Warning: Provider vsphere is undefined
> │ 
> │   on main.tf line 108, in module "vm":
> │  108:     vsphere = vsphere
> │ 
> │ Module module.vm does not declare a provider named vsphere.
> │ If you wish to specify a provider configuration for the module, add an entry for vsphere in the required_providers block within the module.