### PR TITLE
add lifecycle ignore changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -271,4 +271,10 @@ resource "vsphere_virtual_machine" "vm" {
 
   shutdown_wait_timeout = var.shutdown_wait_timeout
   force_power_off       = var.force_power_off
+  lifecycle {
+    ignore_changes = [
+      disk.0.eagerly_scrub,
+      disk.0.thin_provisioned
+    ]
+  }
 }


### PR DESCRIPTION
Because the provider does not support changing disk thin/thick settings for the OS disk and it's possible for a VMware admin to change this setting outside of terraform it doesn't make sense for terraform to fail if this setting has changed.

```
│ Error: disk.0: virtual disk "disk0": cannot change the value of "thin_provisioned" - (old: false newValue: true)
│ 
│   with module.redacted.vsphere_virtual_machine.vm[0],
│   on .terraform/modules/redacted/main.tf line 79, in resource "vsphere_virtual_machine" "vm":
│   79: resource "vsphere_virtual_machine" "vm" {
```