### PR TITLE
Allow Hostname to differ from VMname

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -217,7 +217,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {
-          host_name    = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          host_name    = (var.statichostname == null && var.hostname == null) ? (var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)) : (var.statichostname != null ? var.statichostname : format("${var.hostname}${var.hostnameformat}", count.index + 1))
           domain       = var.domain
           hw_clock_utc = var.hw_clock_utc
         }
@@ -226,7 +226,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "windows_options" {
         for_each = var.is_windows_image ? [1] : []
         content {
-          computer_name         = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          computer_name         = (var.statichostname == null && var.hostname == null) ? (var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)) : (var.statichostname != null ? var.statichostname : format("${var.hostname}${var.hostnameformat}", count.index + 1))
           admin_password        = var.local_adminpass
           workgroup             = var.workgroup
           join_domain           = var.windomain

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,21 @@ variable "storage_policy_id" {
 }
 
 ###########################################
+variable "hostname" {
+  description = "The hostname used for customization. This name can scale out based on number of instances and hostnameformat - example can be found under example folder"
+  default     = "terraformvm"
+}
+
+variable "hostnameformat" {
+  description = "hostname format. default is set to 2 decimal with leading 0. example: %03d for 3 decimal with leading zero or %02dprod for additional suffix"
+  default     = "%02d"
+}
+
+variable "statichostname" {
+  description = "Static hostname for customization. When this option is used VM can not scale out using instance variable. You can use for_each outside the module to deploy multiple static vms with different names"
+  default     = null
+}
+
 variable "vmname" {
   description = "The name of the virtual machine used to deploy the vms. This name can scale out based on number of instances and vmnameformat - example can be found under exampel folder"
   default     = "terraformvm"


### PR DESCRIPTION
In our naming scheme we have vmname set to FQDN, but that doesn't work for hostname on a linux box. So I added a new set of variables `*hostname*` analog to `*vmname*`. I kept backward compatibility by falling back to `*vmname*` vars shoud the `*hostname*` vars be null.

I don't know how apply this to the existing tests, so I didn't.