### PR TITLE
Handle new vmrpid variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ data "vsphere_datastore" "disk_datastore" {
 }
 
 data "vsphere_resource_pool" "pool" {
+  count         = var.vmrp != "" ? 1 : 0
   name          = var.vmrp
   datacenter_id = data.vsphere_datacenter.dc.id
 }
@@ -81,7 +82,7 @@ resource "vsphere_virtual_machine" "vm" {
   depends_on = [var.vm_depends_on]
   name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
 
-  resource_pool_id        = data.vsphere_resource_pool.pool.id
+  resource_pool_id        = var.vmrp != "" ? data.vsphere_resource_pool.pool[0].id : var.vmrpid
   folder                  = var.vmfolder
   tags                    = var.tag_ids != null ? var.tag_ids : data.vsphere_tag.tag[*].id
   custom_attributes       = var.custom_attributes

--- a/output.tf
+++ b/output.tf
@@ -5,7 +5,7 @@ output "DC_ID" {
 
 output "ResPool_ID" {
   description = "Resource Pool id"
-  value       = data.vsphere_resource_pool.pool.id
+  value       = var.vmrp != "" ? data.vsphere_resource_pool.pool[0].id : var.vmrpid
 }
 
 output "VM" {

--- a/variables.tf
+++ b/variables.tf
@@ -175,8 +175,14 @@ variable "dc" {
   description = "Name of the datacenter you want to deploy the VM to."
 }
 
+variable "vmrpid" {
+  description = "ID of cluster resource pool that VM will be deployed to. you use following to choose default pool in the cluster (esxi1) or (Cluster)/Resources."
+  default     = ""
+}
+
 variable "vmrp" {
   description = "Cluster resource pool that VM will be deployed to. you use following to choose default pool in the cluster (esxi1) or (Cluster)/Resources."
+  default     = ""
 }
 
 variable "vmfolder" {


### PR DESCRIPTION
Add new `vmrpid` variable to allow users to provide a resource pool id instead of a resource pool path.

This can be used, for exemple, to link the vSphere VM to a [`vsphere_vapp_container`](https://registry.terraform.io/providers/hashicorp/vsphere/latest/docs/resources/vapp_container) also managed by terraform.