### PR TITLE
Allow the option to override the customize timeout when creating VMs.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -214,6 +214,8 @@ resource "vsphere_virtual_machine" "vm" {
     timeout       = var.timeout
 
     customize {
+      timeout = var.customize_timeout
+      
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {

--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,10 @@ resource "vsphere_virtual_machine" "vm" {
     customize {
       timeout = var.customize_timeout
       
+      lifecycle {
+        ignore_changes = [timeout]
+      }
+      
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {

--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,13 @@ resource "vsphere_virtual_machine" "vm" {
       disk_mode         = lookup(terraform_disks.value, "disk_mode", null)
     }
   }
+  
+  lifecycle {
+    ignore_changes = [
+      clone[0].customize[0].timeout
+    ]
+  }
+  
   clone {
     template_uuid = var.content_library == null ? data.vsphere_virtual_machine.template[0].id : data.vsphere_content_library_item.library_item_template[0].id
     linked_clone  = var.linked_clone
@@ -215,10 +222,6 @@ resource "vsphere_virtual_machine" "vm" {
 
     customize {
       timeout = var.customize_timeout
-      
-      lifecycle {
-        ignore_changes = [timeout]
-      }
       
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]

--- a/variables.tf
+++ b/variables.tf
@@ -236,6 +236,12 @@ variable "timeout" {
   default     = 30
 }
 
+variable "customize_timeout" {
+  description = "The timeout, in minutes, to wait for the virtual machine customizations to complete."
+  type        = number
+  default     = 10
+}
+
 variable "dns_suffix_list" {
   description = "A list of DNS search domains to add to the DNS configuration on the virtual machine."
   type        = list(string)


### PR DESCRIPTION
When provisioning Virtual Machines via this module in Terraform DRS application and other customizations can take longer the the default timeout of 10 minutes. This merge request allows operators to override the default 10 minutes when they know that customizations can take longer. Setting a value of 0 will disable the timeout.