### PR TITLE
feat: Change Network Interface Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,18 @@ module "example-server-linuxvm" {
   instances = 2
   vmname    = "example-server-linux"
   vmrp      = "esxi/Resources - or name of a resource pool"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]; You can also use a CIDR annotation;
-  }
+  network = [
+    {
+      ip_address = "10.13.113.2"
+      port_group = "Name of the Port Group in vSphere"
+    },
+    {
+      ip_address = "10.13.113.3"
+      port_group = "Name of the Port Group in vSphere"
+    },
+
+  ] 
+
   vmgateway = "10.13.113.1"
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
@@ -93,12 +102,30 @@ module "example-server-windowsvm-advanced" {
   vmname            = "AdvancedVM"
   vmnameformat      = "%03d" #To use three decimal with leading zero vmnames will be AdvancedVM001,AdvancedVM002
   domain            = "somedomain.com"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]; You can also use a CIDR annotation;
-    "Second Network Card"               = ["", ""]
-  }
-  ipv4submask  = ["24", "8"]
-  network_type = ["vmxnet3", "vmxnet3"]
+  network = [
+    {
+      ip_address     = "10.13.113.2"
+      network_type   = "vmxnet3"
+      port_group     = "Name of the Port Group in vSphere"
+    },
+    {
+      ip_address     = "10.13.113.3"
+      network_type   = "vmxnet3"
+      port_group     = "Name of the Port Group in vSphere"
+    },
+   {
+      ip_address     = ""
+      network_type   = "vmxnet3"
+      port_group     = "Second Network Card"
+    },
+   {
+      ip_address     = ""
+      network_type   = "vmxnet3"
+      port_group     = "Second Network Card"
+    },
+
+  ] 
+
   tags = {
     "terraform-test-category" = "terraform-test-tag"
   }

--- a/examples/example-Windows-data_disk.tf
+++ b/examples/example-Windows-data_disk.tf
@@ -13,9 +13,21 @@ module "example-server-windowsvm-advanced" {
   instances         = 2
   vmname            = "AdvancedVM"
   domain          = "somedomain.com"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+    {
+        ip_address     = "10.13.113.3"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+  ]
+
   template_storage_policy_id = [data.vsphere_storage_policy.this.id] #Policy ID for the template disks
   data_disk = {
     disk1 = {

--- a/examples/example-linux-Network.tf
+++ b/examples/example-linux-Network.tf
@@ -10,15 +10,36 @@ module "example-server-linuxvm-advanced" {
   instances         = 2
   vmname            = "AdvancedVM"
   domain            = "somedomain.com"
-  ipv4submask       = ["24", "8"]
-  network = {
-    "Network01" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
-    "Network02" = ["", ""]                       #Second Network will use the DHCP
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+        netmask        = ""
+      },
+      {
+        ip_address     = "10.13.113.3"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+        netmask        = ""
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+        netmask        = ""
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+        netmask        = ""
+      },
+  ]
+
   disk_datastore  = "vsanDatastore"
   dns_server_list = ["192.168.0.2", "192.168.0.1"]
   vmgateway       = "192.168.0.1"
-  network_type    = ["vmxnet3", "vmxnet3"]
 }
 
 // Example of Linux VM with Network CIDR
@@ -33,14 +54,41 @@ module "example-server-linuxvm-advanced" {
   instances         = 2
   vmname            = "AdvancedVM"
   domain            = "somedomain.com"
-  network = {
-    "Network01" = ["10.13.113.2/28", "10.13.113.3/28"] # To use DHCP create Empty list ["",""]
-    "Network02" = ["", ""]                             #Second Network will use the DHCP
-    "Network03" = ["10.13.0.2/26", "10.13.0.3/26"]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = "10.13.113.3/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+      },
+      {
+        ip_address     = "10.13.0.2/26"
+        network_type   = "vmxnet3"
+        port_group     = "Network03"
+      },
+      {
+        ip_address     = "10.13.0.3/26"
+        network_type   = "vmxnet3"
+        port_group     = "Network03"
+      },
+
+  ]
   disk_datastore  = "vsanDatastore"
   dns_server_list = ["192.168.0.2", "192.168.0.1"]
   vmgateway       = "192.168.0.1"
-  network_type    = ["vmxnet3", "vmxnet3"]
 }
 

--- a/examples/example-linux-depend_on.tf
+++ b/examples/example-linux-depend_on.tf
@@ -6,10 +6,29 @@ module "example-server-linuxvm" {
   instances     = 1
   vmname        = "example-server-windows"
   vmrp          = "esxi/Resources"
-  network = {
-    "Network01" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
-    "Network02" = ["", ""]                       #Second Network will use the DHCP
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = "10.13.113.3/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+      },
+
+  ]
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
@@ -32,13 +51,31 @@ module "example-server-linuxvm-advanced" {
   vmname                 = "AdvancedVM"
   domain               = "somedomain.com"
   ipv4submask            = ["24", "8"]
-  network = {
-    "Network01" = ["10.13.113.2", "10.13.113.3"] # To use DHCP create Empty list ["",""]
-    "Network02" = ["", ""]                       #Second Network will use the DHCP
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = "10.13.113.3/28"
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network01"
+      },
+      {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Network02"
+      },
+
+  ]
   dns_server_list           = ["192.168.0.2", "192.168.0.1"]
   vmgateway                 = "192.168.0.1"
-  network_type              = ["vmxnet3", "vmxnet3"]
   tags = {
     "terraform-test-category"    = "terraform-test-tag"
     "terraform-test-category-02" = "terraform-test-tag-02"

--- a/examples/example-vmname.tf
+++ b/examples/example-vmname.tf
@@ -5,9 +5,15 @@ module "example-server-single" {
   vmtemp       = "TemplateName"
   staticvmname = "liternalvmname"
   vmrp         = "esxi/Resources"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2"]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+  ]
+
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
@@ -25,9 +31,14 @@ module "example-server-single" {
   vmtemp       = "TemplateName"
   staticvmname = "liternalvmname"
   vmrp         = "esxi/Resources"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2"]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+  ]
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
@@ -44,9 +55,20 @@ module "example-server-multi" {
   vmname       = "advancevm"
   vmnameformat = "%03d${var.env}"
   vmrp         = "esxi/Resources"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", ""]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+    {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+  ]
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
@@ -65,9 +87,20 @@ module "example-server-multi" {
   vmname       = "advancevm"
   vmnameformat = "%03d.${var.domain}"
   vmrp         = "esxi/Resources"
-  network = {
-    "Name of the Port Group in vSphere" = ["10.13.113.2", ""]
-  }
+  network      = [
+      {
+        ip_address     = "10.13.113.2"
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+    {
+        ip_address     = ""
+        network_type   = "vmxnet3"
+        port_group     = "Name of the Port Group in vSphere"
+        netmask        = ""
+    },
+  ]
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }

--- a/tests/sanity/README.md
+++ b/tests/sanity/README.md
@@ -19,10 +19,18 @@ vm = {
     vmfolder         = "fill"
     vmgateway        = "10.13.13.1"
     dns_servers      = ["1.1.1.1"]
-    network = {
-      "VM Port Group" = ["10.13.13.2", ""], # To use DHCP create Empty list for each instance
-      "VM Port Group" = ["", ""]
-    }
+    network = [
+    {
+      ip_address = "10.13.113.2"
+      port_group = "VM Port Group"
+    },
+    {
+      ip_address = "" #use DHCP
+      port_group = "VM Port Group"
+    },
+
+  ] 
+
   },
   windowsvm = {
     vmtemp           = "fill"
@@ -33,10 +41,17 @@ vm = {
     datastore        = "fill"  
     dns_servers      = null
     vmgateway        = "10.13.13.1"
-    network = {
-      "VM Port Group" = ["10.13.13.2", ""], # To use DHCP create Empty list for each instance
-      "VM Port Group" = ["", ""]
-    }
+    network = [
+    {
+      ip_address = "10.13.113.2"
+      port_group = "VM Port Group"
+    },
+    {
+      ip_address = "" #use DHCP
+      port_group = "VM Port Group"
+    },
+  ] 
+
   }
 }
 ```

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,8 @@
 #Network Section
 variable "network" {
-  description = "Define PortGroup and IPs/CIDR for each VM. If no CIDR provided, the subnet mask is taken from var.ipv4submask."
-  type        = map(list(string))
-  default     = {}
-}
-
-variable "network_type" {
-  description = "Define network type for each network interface."
-  type        = list(any)
-  default     = null
-}
-
-variable "ipv4submask" {
-  description = "ipv4 Subnet mask. Warning: The order must follow the alphabetic order from var.network."
-  type        = list(any)
-  default     = ["24"]
+  description = "Define Network interfaces for each VM"
+  type        = list(map(string))
+  default     = []
 }
 
 #Data Disk section


### PR DESCRIPTION
Hi There
We are using this module since a period now but we note that there is an issue when provisionning a machine with multiple network interfaces. ipv4_netmask is get reversed depending on the vlan name (which is listed in alphabetical order) 
Example, with this configuration : 
```
network = {
    "ABC_group" = ["10.13.113.2"] 
    "XYZ_group" = ["10.13.113.3"] 
  }
ipv4submask  = ["24", "8"]
```
Executing a terraform plan will result on this configuration : 

```
...
+ network_interface {
                  + ipv4_address = "10.13.113.2"
                  + ipv4_netmask = 8
                }
+ network_interface {
                  + ipv4_address = "10.13.113.3"
                  + ipv4_netmask = 24
                }
...

```
Because of this https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/blob/master/main.tf#L246

I suggest to change this network configuration block and use a list of map, like this : 

```

network      = [
      {
        ip_address     = "10.13.113.2"
        network_type   = "vmxnet3"
        port_group     = "ABC_group"
        netmask        = "24"
    },
    {
        ip_address     = "10.13.113.3"
        network_type   = "vmxnet3"
        port_group     = "XYZ_group"
        netmask        = "28"
    },
  ]
```

Your comments are welcome ;-) 