### PR TITLE
Vmname instance start number

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   count      = var.instances
   depends_on = [var.vm_depends_on]
-  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)
 
   resource_pool_id        = data.vsphere_resource_pool.pool.id
   folder                  = var.vmfolder
@@ -217,7 +217,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {
-          host_name    = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          host_name    = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)
           domain       = var.domain
           hw_clock_utc = var.hw_clock_utc
         }
@@ -226,7 +226,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "windows_options" {
         for_each = var.is_windows_image ? [1] : []
         content {
-          computer_name         = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          computer_name         = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)
           admin_password        = var.local_adminpass
           workgroup             = var.workgroup
           join_domain           = var.windomain

--- a/tests/sanity/main.tf
+++ b/tests/sanity/main.tf
@@ -52,6 +52,7 @@ module "example-server-basic" {
   datastore        = each.value.datastore
   #starting of static values
   instances      = 2
+  vmstartcount   = 4
   vmnameformat   = "%03d${var.env}.somedomain.com"
   vmname         = "terraform-sanitytest"
   annotation     = "Terraform Sanity Test"

--- a/tests/smoke/main.tf
+++ b/tests/smoke/main.tf
@@ -14,6 +14,7 @@ variable "vm" {
     datastore        = string
     is_windows_image = bool
     instances        = number
+    vmstartcount     = optional(number, 1)
     network          = map(list(string))
     vmgateway        = string
     dns_servers      = list(string)
@@ -27,6 +28,7 @@ module "example-server-basic" {
   annotation       = each.value.annotation
   is_windows_image = each.value.is_windows_image
   instances        = each.value.instances
+  vmstartcount     = each.value.vmstartcount
   vmname           = each.value.vmname
   vmrp             = each.value.vmrp
   vmfolder         = each.value.vmfolder

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,10 @@ variable "vmnameformat" {
   description = "vmname format. default is set to 2 decimal with leading 0. example: %03d for 3 decimal with leading zero or %02dprod for additional suffix"
   default     = "%02d"
 }
+variable "vmstartcount" {
+  description = "vmname start count value. default is set to 1. example: a value of 4 (with default format and 2 instances) will make first instance suffix 04 and second instance suffix 05"
+  default     = 1
+}
 
 variable "staticvmname" {
   description = "Static name of the virtual machin. When this option is used VM can not scale out using instance variable. You can use for_each outside the module to deploy multiple static vms with different names"


### PR DESCRIPTION
(I know there was a new release today, excuse the fact that this was an old update I just merged with new changes)

This pull request enables the ability to start a vmname suffix count to end with a number other than 1.  For example, the first definition of a management server can be created as "server01", and by defining 3 instances with new optional variable vmstartcount set to "2", the next definition of "worker nodes" would create server02/server03/server04.

Included are small changes to smoke/sanity main.tf, which the smoke test showing how it can be defined and still remain optional.  The original main.tf will work too, for backwards compatibility to existing uses.


```
Initializing the backend...
Initializing modules...

Initializing provider plugins...
- Reusing previous version of hashicorp/vsphere from the dependency lock file
- Using previously-installed hashicorp/vsphere v1.24.2

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
Success! The configuration is valid.

module.example-server-basic["windowsvm"].data.vsphere_datacenter.dc: Reading...
module.example-server-basic["linuxvm"].data.vsphere_datacenter.dc: Reading...
module.example-server-basic["windowsvm"].data.vsphere_datacenter.dc: Read complete after 0s [id=datacenter-21]
module.example-server-basic["linuxvm"].data.vsphere_datacenter.dc: Read complete after 0s [id=datacenter-21]
module.example-server-basic["linuxvm"].data.vsphere_datastore.datastore[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_datastore.datastore[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_folder.folder[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_network.network[1]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_network.network[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_folder.folder[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_network.network[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_network.network[1]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_virtual_machine.template[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_virtual_machine.template[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_folder.folder[0]: Read complete after 0s [id=group-v3277]
module.example-server-basic["windowsvm"].data.vsphere_resource_pool.pool[0]: Reading...
module.example-server-basic["windowsvm"].data.vsphere_network.network[0]: Read complete after 0s [id=dvportgroup-1944335]
module.example-server-basic["linuxvm"].data.vsphere_resource_pool.pool[0]: Reading...
module.example-server-basic["linuxvm"].data.vsphere_folder.folder[0]: Read complete after 0s [id=group-v3277]
module.example-server-basic["linuxvm"].data.vsphere_network.network[1]: Read complete after 0s [id=network-339]
module.example-server-basic["windowsvm"].data.vsphere_network.network[1]: Read complete after 0s [id=network-339]
module.example-server-basic["linuxvm"].data.vsphere_network.network[0]: Read complete after 0s [id=dvportgroup-1944335]
module.example-server-basic["linuxvm"].data.vsphere_resource_pool.pool[0]: Read complete after 0s [id=resgroup-821251]
module.example-server-basic["windowsvm"].data.vsphere_resource_pool.pool[0]: Read complete after 0s [id=resgroup-821251]
module.example-server-basic["windowsvm"].data.vsphere_datastore.datastore[0]: Read complete after 0s [id=datastore-1003408]
module.example-server-basic["linuxvm"].data.vsphere_datastore.datastore[0]: Read complete after 0s [id=datastore-1003408]
module.example-server-basic["linuxvm"].data.vsphere_virtual_machine.template[0]: Read complete after 1s [id=42149e37-ef52-14da-1a27-792f6dd20a57]
module.example-server-basic["windowsvm"].data.vsphere_virtual_machine.template[0]: Read complete after 1s [id=42149372-d6b3-e625-8965-e0907176c619]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-1003408"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "Templates"
      + force_power_off                         = true
      + guest_id                                = "rhel7_64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "linuxtest-04"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-821251"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42149e37-ef52-14da-1a27-792f6dd20a57"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.29.140.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "linuxtest-04"
                  + hw_clock_utc = true
                }

              + network_interface {
                  + ipv4_address = "172.29.140.196"
                  + ipv4_netmask = 24
                }
              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 100
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-1944335"
        }
      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-339"
        }
    }

  # module.example-server-basic["linuxvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-1003408"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "Templates"
      + force_power_off                         = true
      + guest_id                                = "rhel7_64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "linuxtest-05"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-821251"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "pvscsi"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42149e37-ef52-14da-1a27-792f6dd20a57"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.29.140.1"
              + timeout      = 10

              + linux_options {
                  + domain       = "Development.com"
                  + host_name    = "linuxtest-05"
                  + hw_clock_utc = true
                }

              + network_interface {
                  + ipv4_address = "172.29.140.197"
                  + ipv4_netmask = 24
                }
              + network_interface {}
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 100
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-1944335"
        }
      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-339"
        }
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[0] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-1003408"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "Templates"
      + force_power_off                         = true
      + guest_id                                = "windows9Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "windowstest-01"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-821251"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "lsilogic-sas"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42149372-d6b3-e625-8965-e0907176c619"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.29.140.1"
              + timeout      = 10

              + network_interface {
                  + ipv4_address = "172.29.140.198"
                  + ipv4_netmask = 24
                }
              + network_interface {}

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "windowstest-01"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 80
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-1944335"
        }
      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-339"
        }
    }

  # module.example-server-basic["windowsvm"].vsphere_virtual_machine.vm[1] will be created
  + resource "vsphere_virtual_machine" "vm" {
      + boot_retry_delay                        = 10000
      + change_version                          = (known after apply)
      + cpu_limit                               = -1
      + cpu_share_count                         = (known after apply)
      + cpu_share_level                         = "normal"
      + datastore_id                            = "datastore-1003408"
      + default_ip_address                      = (known after apply)
      + efi_secure_boot_enabled                 = false
      + enable_disk_uuid                        = false
      + ept_rvi_mode                            = "automatic"
      + firmware                                = "bios"
      + folder                                  = "Templates"
      + force_power_off                         = true
      + guest_id                                = "windows9Server64Guest"
      + guest_ip_addresses                      = (known after apply)
      + hardware_version                        = (known after apply)
      + host_system_id                          = (known after apply)
      + hv_mode                                 = "hvAuto"
      + id                                      = (known after apply)
      + ide_controller_count                    = 2
      + ignored_guest_ips                       = []
      + imported                                = (known after apply)
      + latency_sensitivity                     = "normal"
      + memory                                  = 4096
      + memory_limit                            = -1
      + memory_share_count                      = (known after apply)
      + memory_share_level                      = "normal"
      + migrate_wait_timeout                    = 30
      + moid                                    = (known after apply)
      + name                                    = "windowstest-02"
      + num_cores_per_socket                    = 1
      + num_cpus                                = 2
      + poweron_timeout                         = 300
      + reboot_required                         = (known after apply)
      + resource_pool_id                        = "resgroup-821251"
      + run_tools_scripts_after_power_on        = true
      + run_tools_scripts_after_resume          = true
      + run_tools_scripts_before_guest_shutdown = true
      + run_tools_scripts_before_guest_standby  = true
      + sata_controller_count                   = 0
      + scsi_bus_sharing                        = "noSharing"
      + scsi_controller_count                   = 1
      + scsi_type                               = "lsilogic-sas"
      + shutdown_wait_timeout                   = 3
      + storage_policy_id                       = (known after apply)
      + swap_placement_policy                   = "inherit"
      + uuid                                    = (known after apply)
      + vapp_transport                          = (known after apply)
      + vmware_tools_status                     = (known after apply)
      + vmx_path                                = (known after apply)
      + wait_for_guest_ip_timeout               = 0
      + wait_for_guest_net_routable             = true
      + wait_for_guest_net_timeout              = 5

      + clone {
          + linked_clone  = false
          + template_uuid = "42149372-d6b3-e625-8965-e0907176c619"
          + timeout       = 30

          + customize {
              + ipv4_gateway = "172.29.140.1"
              + timeout      = 10

              + network_interface {
                  + ipv4_address = "172.29.140.199"
                  + ipv4_netmask = 24
                }
              + network_interface {}

              + windows_options {
                  + auto_logon_count  = 1
                  + computer_name     = "windowstest-02"
                  + full_name         = "Administrator"
                  + organization_name = "Managed by Terraform"
                  + time_zone         = 85
                }
            }
        }

      + disk {
          + attach            = false
          + controller_type   = "scsi"
          + datastore_id      = "<computed>"
          + device_address    = (known after apply)
          + disk_mode         = "persistent"
          + disk_sharing      = "sharingNone"
          + eagerly_scrub     = false
          + io_limit          = -1
          + io_reservation    = 0
          + io_share_count    = 0
          + io_share_level    = "normal"
          + keep_on_remove    = false
          + key               = 0
          + label             = "disk0"
          + path              = (known after apply)
          + size              = 80
          + storage_policy_id = (known after apply)
          + thin_provisioned  = true
          + unit_number       = 0
          + uuid              = (known after apply)
          + write_through     = false
        }

      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "dvportgroup-1944335"
        }
      + network_interface {
          + adapter_type          = "vmxnet3"
          + bandwidth_limit       = -1
          + bandwidth_reservation = 0
          + bandwidth_share_count = (known after apply)
          + bandwidth_share_level = "normal"
          + device_address        = (known after apply)
          + key                   = (known after apply)
          + mac_address           = (known after apply)
          + network_id            = "network-339"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.
```