### PR TITLE
Vmname fqdn and instance start number support

### DIFF
--- a/examples/example-vmname.tf
+++ b/examples/example-vmname.tf
@@ -54,16 +54,15 @@ module "example-server-multi" {
 #
 //Example of appending domain name to vm name
 
-variable "domain" {
-  default = "somedomain.com"
-}
-module "example-server-multi" {
+module "example-server-fqdnvmname" {
   source       = "Terraform-VMWare-Modules/vm/vsphere"
   version      = "Latest X.X.X"
   vmtemp       = "TemplateName"
   instances    = 2
   vmname       = "advancevm"
-  vmnameformat = "%03d.${var.domain}"
+  vmnameformat = "%03d"
+  domain       = "somedomain.com"
+  fqdnvmname   = true
   vmrp         = "esxi/Resources"
   network = {
     "Name of the Port Group in vSphere" = ["10.13.113.2", ""]
@@ -71,4 +70,24 @@ module "example-server-multi" {
   dc        = "Datacenter"
   datastore = "Data Store name(use datastore_cluster for datastore cluster)"
 }
-# Vmname Output -> advancevm001.somedomain.com, advancevm002dev.somedomain.com
+# Vmname Output -> advancevm001.somedomain.com, advancevm002.somedomain.com
+#
+//Example of using a starting number other than "1" for the vmname with multiple instances
+
+module "example-server-vmstartcount" {
+  source       = "Terraform-VMWare-Modules/vm/vsphere"
+  version      = "Latest X.X.X"
+  vmtemp       = "TemplateName"
+  instances    = 2
+  vmstartcount = 5
+  vmname       = "advancevm"
+  vmnameformat = "%03d"
+  vmrp         = "esxi/Resources"
+  network = {
+    "Name of the Port Group in vSphere" = ["10.13.113.2", ""]
+  }
+  dc        = "Datacenter"
+  datastore = "Data Store name(use datastore_cluster for datastore cluster)"
+}
+# Vmname Output -> advancevm005, advancevm006
+

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   count      = var.instances
   depends_on = [var.vm_depends_on]
-  name       = "${var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)}${var.fqdnvmname == true ? ".${var.domain}" : ""}"
+  name       = "${var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)}${var.fqdnvmname == true ? ".${var.domain}" : ""}"
 
   resource_pool_id        = var.vmrp != "" ? data.vsphere_resource_pool.pool[0].id : var.vmrpid
   folder                  = var.vmfolder
@@ -218,7 +218,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "linux_options" {
         for_each = var.is_windows_image ? [] : [1]
         content {
-          host_name    = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          host_name    = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)
           domain       = var.domain
           hw_clock_utc = var.hw_clock_utc
         }
@@ -227,7 +227,7 @@ resource "vsphere_virtual_machine" "vm" {
       dynamic "windows_options" {
         for_each = var.is_windows_image ? [1] : []
         content {
-          computer_name         = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+          computer_name         = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + var.vmstartcount)
           admin_password        = var.local_adminpass
           workgroup             = var.workgroup
           join_domain           = var.windomain

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ locals {
 resource "vsphere_virtual_machine" "vm" {
   count      = var.instances
   depends_on = [var.vm_depends_on]
-  name       = var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)
+  name       = "${var.staticvmname != null ? var.staticvmname : format("${var.vmname}${var.vmnameformat}", count.index + 1)}${var.fqdnvmname == true ? ".${var.domain}" : ""}"
 
   resource_pool_id        = var.vmrp != "" ? data.vsphere_resource_pool.pool[0].id : var.vmrpid
   folder                  = var.vmfolder

--- a/tests/sanity/main.tf
+++ b/tests/sanity/main.tf
@@ -52,7 +52,10 @@ module "example-server-basic" {
   datastore        = each.value.datastore
   #starting of static values
   instances      = 2
-  vmnameformat   = "%03d${var.env}.somedomain.com"
+  vmstartcount   = 5
+  vmnameformat   = "%03d${var.env}"
+  domain         = "somedomain.com"
+  fqdnvmname     = true
   vmname         = "terraform-sanitytest"
   annotation     = "Terraform Sanity Test"
   tag_depends_on = [vsphere_tag.tag.id]

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,11 @@ variable "vmnameformat" {
   default     = "%02d"
 }
 
+variable "vmstartcount" {
+  description = "vmname start count value. default is set to 1. example: a value of 4 (with default format and 2 instances) will make first instance suffix 04 and second instance suffix 05"
+  default     = 1
+}
+
 variable "staticvmname" {
   description = "Static name of the virtual machin. When this option is used VM can not scale out using instance variable. You can use for_each outside the module to deploy multiple static vms with different names"
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,12 @@ variable "staticvmname" {
   default     = null
 }
 
+variable "fqdnvmname" {
+  description = "If true, the vm will be created using domain variable appended"
+  type        = bool
+  default     = false
+}
+
 variable "vmtemp" {
   description = "Name of the template available in the vSphere."
 }
@@ -307,7 +313,7 @@ variable "hw_clock_utc" {
 }
 
 variable "domain" {
-  description = "default VM domain for linux guest customization."
+  description = "default VM domain for linux guest customization and fqdn name (if fqdnvmname is true)."
   default     = "Development.com"
 }
 


### PR DESCRIPTION
This is the combined changes of PR149 and PR150, along with an updated example-vmname.tf to reflect various ways to use the two new optional features:

1. Ability to create VMs using the FQDN as the vm's name as seen in VMware 
2. Ability to create multiple instances using a starting number other than "1"

The sanity test was also updated to test new features, and both sanity and smoke tests were performed with Terraform v1.3.5 and v1.5.0.  Attached are the sanity and smoke test outputs from the included plan.sh.

[sanity_output.txt](https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/files/11761172/sanity_output.txt)
[smoke_output.txt](https://github.com/Terraform-VMWare-Modules/terraform-vsphere-vm/files/11761184/smoke_output.txt)
