### PR TITLE
Conversion of RAM size from MB to GB

### DIFF
--- a/examples/example-linux-depend_on.tf
+++ b/examples/example-linux-depend_on.tf
@@ -25,7 +25,7 @@ module "example-server-linuxvm-advanced" {
   vmtemp                 = "TemplateName"
   instances              = 2
   cpu_number             = 2
-  ram_size               = 2096
+  ram_size               = 2
   cpu_hot_add_enabled    = true
   cpu_hot_remove_enabled = true
   memory_hot_add_enabled = true

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "vsphere_virtual_machine" "vm" {
   cpu_share_level        = var.cpu_share_level
   cpu_share_count        = var.cpu_share_level == "custom" ? var.cpu_share_count : null
   memory_reservation     = var.memory_reservation
-  memory                 = var.ram_size
+  memory                 = var.ram_size * 1024
   memory_hot_add_enabled = var.memory_hot_add_enabled
   memory_share_level     = var.memory_share_level
   memory_share_count     = var.memory_share_level == "custom" ? var.memory_share_count : null

--- a/variables.tf
+++ b/variables.tf
@@ -167,8 +167,8 @@ variable "cpu_share_count" {
 }
 
 variable "ram_size" {
-  description = "VM RAM size in megabytes."
-  default     = 4096
+  description = "VM RAM size in gigabytes."
+  default     = 4
 }
 
 variable "dc" {


### PR DESCRIPTION
## **Brief Description**:
This is a simple variable 
change and additional operator to convert MB to GB for ram_size. This change supports Floats and Integers. For example, if you want `6.5`GB RAM, the module will interpret this to vSphere as `6656` MB.

### Why?: 
As damnsam kindly mentioned below about the intended use of operators for singleton tf files calling this module, I do think having Gigabyte as the default is convenient and avoids the common mistake (At least, I think based on my experience)  inputting the incorrect RAM values. 

### Suggestion:
If this idea doesn't make it through to the module, I would suggest documenting this possibility to users and/or making another/updating .tf example (which I insist on doing)

All the best
Reece