### PR TITLE
Network and disk updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -207,6 +207,9 @@ resource "vsphere_virtual_machine" "vm" {
       io_share_level    = lookup(terraform_disks.value, "io_share_level", "normal")
       io_share_count    = lookup(terraform_disks.value, "io_share_level", null) == "custom" ? lookup(terraform_disks.value, "io_share_count") : null
       disk_mode         = lookup(terraform_disks.value, "disk_mode", null)
+      disk_sharing      = lookup(terraform_disks.value, "disk_sharing", null)
+      attach            = lookup(terraform_disks.value, "attach", null)
+      path              = lookup(terraform_disks.value, "path", null)
     }
   }
   clone {

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "vsphere_resource_pool" "pool" {
 
 data "vsphere_network" "network" {
   count         = length(var.network)
-  name          = keys(var.network)[count.index]
+  name          = var.network_delimiter != null ? split(var.network_delimiter,keys(var.network)[count.index])[1] : keys(var.network)[count.index]
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "network" {
   default     = {}
 }
 
+variable "network_delimiter" {
+  description = "If network name needs a delimiter for sequencing, define an UNUSED character here, otherwise leave as null"
+  type        = string
+  default     = null
+}
+
 variable "network_type" {
   description = "Define network type for each network interface."
   type        = list(any)


### PR DESCRIPTION
This pull request is to add two new features:

1. Add three new properties to data_disk (`disk_sharing`, `attach`, and `path`)

These three new properties (along with the existing `datastore_id`, `disk_mode` and `unit_number`) are required to enable the ability to add shared disks created by a separate `"vsphere_virtual_disk"` resource. For example, a main.tf could contain:

```
data "vsphere_datacenter" "dc" {
  name = "DC"
}
data "vsphere_datastore" "shared-ds" {
  name          = "shared-datastore"
  datacenter_id = "${data.vsphere_datacenter.dc.id}"
}
resource "vsphere_virtual_disk" "data_disk01" {
  vmdk_path  = "/shared-disks/shared-disk01.vmdk"
  datastore  = data.vsphere_datastore.shared-ds.name
  size       = 512
  datacenter = data.vsphere_datacenter.dc.name
  type       = "eagerZeroedThick"
}
module "shared-disks-vms" {
  source           = "Terraform-VMWare-Modules/vm/vsphere"
  version          = "Latest X.X.X"
  vmtemp           = "TemplateName"
  instances        = 2
  vmname           = "shared-vm"
  vmrp             = "esxi/Resources"
  enable_disk_uuid = true
  network   = { "portgroupname" = ["",""] }
  dc        = "${data.vsphere_datacenter.dc.name}"
  datastore = "DataStore Name(datastore_cluster does not work with shared disks)"
  data_disk = {
    disk1 = {
      attach           = true,
      path             = vsphere_virtual_disk.data_disk01.vmdk_path,
      datastore_id     = data.vsphere_datastore.shared-ds.id,
      unit_number      = 15,
      disk_mode        = "independent_persistent",
      disk_sharing     = "sharingMultiWriter"
    }
  }
}
```
This would create shared-vm01 and shared-vm02, each with the same shared disk at SCSI1:0 (unit_number 15), which can be used as an ASM disk for Oracle, GFS2 disk for shared filesystems, etc.

2. Add a new variable `network_delimiter` to help with NIC sequencing.

#155 This issue brought up that NICs are not ordered by sequence, but apparently reordered alphabetically.  A new variable `network_delimiter` can be used to define a character to split the portgroup name into elements, using the first element as an arbitrary way of ordering the NICS, and the second element as the portgroup name to be used. for flexibility, the user can choose their own delimiter that is known to not already be in use, some vCenter environments may actually use ":" and would prefer to use another like a comma, semicolon, or another character as needed.  (There is no known restriction to special characters for portgroup name).  If left as "null", then original functionality remains.

```
...
network_delimiter = ":"
network           = { 
  "1:ProdNet"   = ["10.1.1.1"],
  "2:BackupNet" = ["192.168.1.1"]
}
...
```
This will effectively make the first NIC attached to "ProdNet" and the second NIC attached to "BackupNet".  Prior to using the delimiter, 'BackupNet" would be the first NIC.

I will attach the smoke and sanity outputs below, even though both additions above preserves existing functionality.