### PR TITLE
fix: Adding data source to get the host_system_id

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,13 @@ variable "disk_datastore" {
   type        = string
   default     = ""
 }
+
+variable "esxi_host" {
+  description = "Define the vsphere ESXI host"
+  type        = string
+  default     = ""
+}
+
 variable "io_reservation" {
   description = "The I/O reservation (guarantee) that this disk has, in IOPS. The default is no reservation."
   type        = list(number)


### PR DESCRIPTION
This PR is to add the data source to get the `host_system_id`, which helps to define the host where the VM is going to be hosted. 

We need to pass the name of the ESXI host in order to get the host ID and place the VMs on it. For example, 

```

module "vm_creation" {
  for_each        = var.vm
  source          = "Terraform-VMWare-Modules/vm/vsphere"
  version         = "3.8.0"
  cpu_number      = var.vm_cpu
  dc              = var.dc_name[var.vsphere_datacentre]
  datastore       = lookup(each.value, "datastore_name", var.datastore_name[var.vsphere_datacentre])
  dns_server_list = var.dns_list
  dns_suffix_list = var.dns_search
  domain          = var.domain_name
  network         = each.value.network
  ram_size        = var.vm_ram
  staticvmname    = "${var.vsphere_datacentre}-${each.value.vmname}"
  vmfolder        = var.folder_name
  vmgateway       = each.value.vmgateway
  vmrp            = var.pool_name[var.vsphere_datacentre]
  vmtemp          = var.vm_template[var.vsphere_datacentre]
  io_share_level  = ["normal", "normal"]
  content_library = var.content_library
  firmware        = var.firmware
  disk_size_gb    = var.disk_size_gb
  esxi_host       = lookup(each.value, "esxi_host", var.esxi_host)
}

variable "esxi_host" {
  description = "ESXi host id"
  default     = ""
  type        = string
}

variable "vm" {
  type = map(object({
    network        = map(list(string))
    vmname         = string
    vmgateway      = string
    datastore_name = string
    esxi_host      = string
  }))
}

locals {
vsphere_datacentre = "idev"
dc_name = {
  idev = "IDEV-Base-DC"
}

folder_name = "core/dns"

pool_name = {
  idev = "IDEV-Base-Cluster/Resources"
}

vsphere_subnet_id = "5300" #subnet_id for idev vlan122
vsphere_env       = "idev"

vm = {
  coredns_vm_1 = {
    vmname    = "coredns-1",
    vmgateway = "10.1.125.1"
    network = {
      "vlan125" = ["10.1.125.101"],
    }
    datastore_name = "idev-raid1"
    esxi_host      = "idev-esx-base-01.dev.com"
  },
  coredns_vm_2 = {
    vmname    = "coredns-2",
    vmgateway = "10.1.125.1"
    network = {
      "vlan125" = ["10.1.125.102"],
    }
    datastore_name = "idev-esx-02-local-raid1"
    esxi_host      = "idev-esx-base-2.dev.com"
  }
}
}
```

Sanity check : https://gist.github.com/gowgopal83/1a79c7bb78773b699e10c8216212f8f5