### PR TITLE
fix: adding ovf mapping

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,7 @@ resource "vsphere_virtual_machine" "vm" {
     content {
       network_id   = data.vsphere_network.network[network_interface.key].id
       adapter_type = var.network_type != null ? var.network_type[network_interface.key] : (var.content_library == null ? data.vsphere_virtual_machine.template[0].network_interface_types[0] : null)
+      ovf_mapping  = "nic${network_interface.key}"
     }
   }
   // Disks defined in the original template


### PR DESCRIPTION
Adding ovf_mapping for the network interface in order to prevent vsphere error in case of number network interface in ovf , is inferior to number of nic needed for the deployed VM